### PR TITLE
Investigates pybind11 overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,4 @@ _doc/sphinxdoc/source/phdoc_static/viz.js
 bb.bat
 cpyquickhelper/fastdata/fast_dict_cpy.c
 cpyquickhelper/fastdata/fast_dict_cpy.cpp
+_unittests/unittests.out

--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,5 @@ _doc/sphinxdoc/source/_temp_custom_run_script_.py.pkl
 _doc/sphinxdoc/source/_temp_custom_run_script_.py
 _doc/sphinxdoc/source/phdoc_static/viz.js
 bb.bat
+cpyquickhelper/fastdata/fast_dict_cpy.c
+cpyquickhelper/fastdata/fast_dict_cpy.cpp

--- a/_doc/examples/plot_profiling.py
+++ b/_doc/examples/plot_profiling.py
@@ -11,7 +11,8 @@ EventProfiler
 Many profilers propose to see how long a program stays
 in a function (see :mod:`cProfile`, :epkg:`pyinstrument`,
 :epkg:`palanteer`). This one logs events. It merges function calls
-and memory allocations.
+and memory allocations. We compare the insertion and the search
+of many elements.
 
 .. contents::
     :local:

--- a/_doc/examples/plot_profiling_dict.py
+++ b/_doc/examples/plot_profiling_dict.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+"""
+
+.. _l-example-event-profling-dict:
+
+Profiling of dictionary
+=======================
+
+.. index:: event, profiling, dictionary
+
+Implementation Python dictionary is quite efficient.
+It is possible to replace it with a C++ implementation?
+The following code compares several implementation of
+a dictionary ``{ str, int: int }``.
+
+.. contents::
+    :local:
+
+Implementation to compare
++++++++++++++++++++++++++
+"""
+
+import matplotlib.pyplot as plt
+import pandas
+from cpyquickhelper.fastdata.fast_dict import (
+    FastDictStrInt64, FastDictInt64Int64, FastDictIntInt)
+from cpyquickhelper.fastdata.fast_dict_c import (
+    UnorderedMapStrInt64_Create, UnorderedMapStrInt64_Insert,
+    UnorderedMapStrInt64_Get, UnorderedMapStrInt64_Get_Fast,
+    UnorderedMapStrInt64_Insert_Fast,
+    UnorderedMapRHStrInt64_Create, UnorderedMapRHStrInt64_Insert_Fast,
+    UnorderedMapRHStrInt64_Get_Fast)
+from pyquickhelper.pycode.profiling import profile, profile2graph
+
+
+data = [("*" * (i // 2), i, i) for i in range(0, 100)]
+fcts = []
+
+
+class UnorderedMapRHStrInt64:
+
+    def __init__(self):
+        self.obj = UnorderedMapRHStrInt64_Create()
+
+    def insert_fast(self, name, key, value):
+        UnorderedMapRHStrInt64_Insert_Fast(self.obj, name, key, value)
+
+    def get_fast(self, name, key, default_value):
+        return UnorderedMapRHStrInt64_Get_Fast(self.obj, name, key, default_value)
+
+####################################
+# Python implementation
+
+
+def insert_py(d):
+    for n, k, v in data:
+        d[n, k] = v
+
+
+def insert_py2(d):
+    for n, k, v in data:
+        if k in d:
+            d[k][n] = v
+        else:
+            d[k] = {n: v}
+
+
+def fct_py():
+    d1 = {}
+    insert_py(d1)
+    get_py(d1)
+
+
+fcts.append(fct_py)
+
+#########################################
+# Second Python implementation
+
+
+def g_py(d, n, k, v):
+    return d.get((n, k), 0)
+
+
+def get_py(d):
+    for n, k, v in data:
+        g_py(d, n, k, v)
+
+
+def g_py2(d, n, k, v):
+    if k in d:
+        if n in d[k]:
+            return d[k][n]
+    return v
+
+
+def get_py2(d):
+    for n, k, v in data:
+        g_py2(d, n, k, v)
+
+
+def fct_py2():
+    d11 = {}
+    insert_py2(d11)
+    get_py2(d11)
+
+
+fcts.append(fct_py2)
+
+
+#############################################
+# pybind11 + unordered_map
+
+def insert_c11(d):
+    for n, k, v in data:
+        d.insert(n, k, v)
+
+
+def get_c11(d):
+    for n, k, _ in data:
+        d.get(n, k, 0)
+
+
+def fct_c11():
+    d2 = FastDictStrInt64()
+    insert_c11(d2)
+    get_c11(d2)
+
+
+fcts.append(fct_c11)
+
+#############################################
+# C API + unordered_map + wrapper
+
+
+class UnorderedMapStrInt64:
+
+    def __init__(self):
+        self.obj = UnorderedMapStrInt64_Create()
+
+    def insert(self, name, key, value):
+        UnorderedMapStrInt64_Insert(self.obj, name, key, value)
+
+    def insert_fast(self, name, key, value):
+        UnorderedMapStrInt64_Insert_Fast(self.obj, name, key, value)
+
+    def get(self, name, key, default_value):
+        return UnorderedMapStrInt64_Get(self.obj, name, key, default_value)
+
+    def get_fast(self, name, key, default_value):
+        return UnorderedMapStrInt64_Get_Fast(self.obj, name, key, default_value)
+
+
+def insert_c(d):
+    for n, k, v in data:
+        d.insert(n, k, v)
+
+
+def get_c(d):
+    for n, k, _ in data:
+        d.get(n, k, 0)
+
+
+def fct_c():
+    d3 = UnorderedMapStrInt64()
+    insert_c(d3)
+    get_c(d3)
+
+
+fcts.append(fct_c)
+
+#############################################
+# C API + unordered_map
+
+
+def insert_c2(d):
+    for n, k, v in data:
+        UnorderedMapStrInt64_Insert(d, n, k, v)
+
+
+def get_c2(d):
+    for n, k, _ in data:
+        UnorderedMapStrInt64_Get(d, n, k, 0)
+
+
+def fct_c2():
+    d3c = UnorderedMapStrInt64_Create()
+    insert_c2(d3c)
+    get_c2(d3c)
+
+
+fcts.append(fct_c2)
+
+#############################################
+# C API + unordered_map + FAST CALL
+
+
+def insert_c_fast(d):
+    for n, k, v in data:
+        UnorderedMapStrInt64_Insert_Fast(d, n, k, v)
+
+
+def get_c_fast(d):
+    for n, k, _ in data:
+        UnorderedMapStrInt64_Get_Fast(d, n, k, 0)
+
+
+def fct_c_fast():
+    d3cf = UnorderedMapStrInt64_Create()
+    insert_c_fast(d3cf)
+    get_c_fast(d3cf)
+
+
+fcts.append(fct_c_fast)
+
+########################################
+# C API + unordered_map + FAST CALL + a different
+# implementation, `martinus/robin-hood-hashing
+# <https://github.com/martinus/robin-hood-hashing>`_
+
+
+def insert_c_fast_rh(d):
+    for n, k, v in data:
+        UnorderedMapRHStrInt64_Insert_Fast(d, n, k, v)
+
+
+def get_c_fast_rh(d):
+    for n, k, _ in data:
+        UnorderedMapRHStrInt64_Get_Fast(d, n, k, 0)
+
+
+def fct_c_fast_rh():
+    d3cfrh = UnorderedMapRHStrInt64_Create()
+    insert_c_fast_rh(d3cfrh)
+    get_c_fast_rh(d3cfrh)
+
+
+fcts.append(fct_c_fast_rh)
+
+#########################################
+# Profiling
+# +++++++++
+
+
+def fctN(N=4000):
+    for _ in range(N):
+        for f in fcts:
+            f()
+
+
+def clean_name(text):
+    text = text.replace("\\", "/")
+    return text.split("/examples/")[-1]
+
+
+ps = profile(fctN)[0]
+root, nodes = profile2graph(ps, clean_text=clean_name)
+text = root.to_text()
+print(text)
+
+###################################
+# Visually.
+
+data = []
+for node in root:
+    data.append(dict(name=node.func_name, time=node.tall))
+df = pandas.DataFrame(data).set_index('name').sort_values('time')
+
+fig, ax = plt.subplots(1, 1, figsize=(20, 4))
+df.plot.barh(title="Profiling", ax=ax)
+fig.tight_layout()
+
+# plt.show()

--- a/_unittests/ut_documentation/test_run_notebooks.py
+++ b/_unittests/ut_documentation/test_run_notebooks.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import platform
 from pyquickhelper.loghelper import fLOG
-from pyquickhelper.pycode import ExtTestCase, skipif_appveyor
+from pyquickhelper.pycode import ExtTestCase
 from pyquickhelper.ipythonhelper import test_notebook_execution_coverage
 import cpyquickhelper
 

--- a/_unittests/ut_documentation/test_run_notebooks.py
+++ b/_unittests/ut_documentation/test_run_notebooks.py
@@ -16,6 +16,8 @@ class TestRunNotebooksPython(ExtTestCase):
 
     @unittest.skipIf(platform.system().lower() == "darwin",
                      reason="no openmp")
+    @unittest.skipIf(platform.system().lower() == "windows",
+                     reason="bug in pytest")
     def test_run_notebooks_branching(self):
         fLOG(
             __file__,
@@ -31,7 +33,8 @@ class TestRunNotebooksPython(ExtTestCase):
         test_notebook_execution_coverage(
             __file__, "branching", folder, 'cpyquickhelper', fLOG=fLOG)
 
-    @skipif_appveyor("unstable issue")
+    @unittest.skipIf(platform.system().lower() == "windows",
+                     reason="bug in pytest")
     def test_run_notebooks_nobranching(self):
         fLOG(
             __file__,

--- a/_unittests/ut_fastdata/test_fast_dict.py
+++ b/_unittests/ut_fastdata/test_fast_dict.py
@@ -8,7 +8,43 @@ from pyquickhelper.pycode import ExtTestCase
 from cpyquickhelper.fastdata.fast_dict import (
     FastDictStrInt64, FastDictInt64Int64, FastDictIntInt)
 from cpyquickhelper.fastdata.fast_dict_cpy import cmap_int_int
+from cpyquickhelper.fastdata.fast_dict_c import (
+    UnorderedMapStrInt64_Create, UnorderedMapStrInt64_Insert,
+    UnorderedMapStrInt64_Get, UnorderedMapStrInt64_Get_Fast,
+    UnorderedMapStrInt64_Insert_Fast,
+    UnorderedMapRHStrInt64_Create, UnorderedMapRHStrInt64_Insert_Fast,
+    UnorderedMapRHStrInt64_Get_Fast)
 from cpyquickhelper import __file__ as rootfile
+
+
+class UnorderedMapStrInt64:
+
+    def __init__(self):
+        self.obj = UnorderedMapStrInt64_Create()
+
+    def insert(self, name, key, value):
+        UnorderedMapStrInt64_Insert(self.obj, name, key, value)
+
+    def insert_fast(self, name, key, value):
+        UnorderedMapStrInt64_Insert_Fast(self.obj, name, key, value)
+
+    def get(self, name, key, default_value):
+        return UnorderedMapStrInt64_Get(self.obj, name, key, default_value)
+
+    def get_fast(self, name, key, default_value):
+        return UnorderedMapStrInt64_Get_Fast(self.obj, name, key, default_value)
+
+
+class UnorderedMapRHStrInt64:
+
+    def __init__(self):
+        self.obj = UnorderedMapRHStrInt64_Create()
+
+    def insert_fast(self, name, key, value):
+        UnorderedMapRHStrInt64_Insert_Fast(self.obj, name, key, value)
+
+    def get_fast(self, name, key, default_value):
+        return UnorderedMapRHStrInt64_Get_Fast(self.obj, name, key, default_value)
 
 
 class TestFastDict(ExtTestCase):
@@ -26,6 +62,46 @@ class TestFastDict(ExtTestCase):
             self.assertEqual(len(d1), len(d2))
             self.assertEqual(d1.get((name, key), 0), value)
             self.assertEqual(d2.get(name, key, 0), value)
+
+    def test_fast_dict_c_str(self):
+        keys = [('A', 6, 7), ('ghhj', 7, 8)]
+        d1 = {}
+        d2 = UnorderedMapStrInt64()
+        for name, key, value in keys:
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get(name, key, 0), 0)
+            self.assertEqual(d2.get_fast(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert(name, key, value)
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get(name, key, 0), value)
+            self.assertEqual(d2.get_fast(name, key, 0), value)
+
+    def test_fast_dict_c_str_fast(self):
+        keys = [('A', 6, 7), ('ghhj', 7, 8)]
+        d1 = {}
+        d2 = UnorderedMapStrInt64()
+        for name, key, value in keys:
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get(name, key, 0), 0)
+            self.assertEqual(d2.get_fast(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert_fast(name, key, value)
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get(name, key, 0), value)
+            self.assertEqual(d2.get_fast(name, key, 0), value)
+
+    def test_fast_dict_c_str_fast_robin_hood(self):
+        keys = [('A', 6, 7), ('ghhj', 7, 8)]
+        d1 = {}
+        d2 = UnorderedMapRHStrInt64()
+        for name, key, value in keys:
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get_fast(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert_fast(name, key, value)
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get_fast(name, key, 0), value)
 
     def test_fast_dict_int64(self):
         keys = [(2, 6, 7), (3, 7, 8)]
@@ -122,11 +198,67 @@ class TestFastDict(ExtTestCase):
             insert2(d2)
             get2(d2)
 
+        def insert3(d):
+            for n, k, v in data:
+                d.insert(n, k, v)
+
+        def get3(d):
+            for n, k, _ in data:
+                d.get(n, k, 0)
+
+        def fct3():
+            d3 = UnorderedMapStrInt64()
+            insert3(d3)
+            get3(d3)
+
+        def insert3c(d):
+            for n, k, v in data:
+                UnorderedMapStrInt64_Insert(d, n, k, v)
+
+        def get3c(d):
+            for n, k, _ in data:
+                UnorderedMapStrInt64_Get(d, n, k, 0)
+
+        def fct3c():
+            d3c = UnorderedMapStrInt64_Create()
+            insert3c(d3c)
+            get3c(d3c)
+
+        def insert3cf(d):
+            for n, k, v in data:
+                UnorderedMapStrInt64_Insert_Fast(d, n, k, v)
+
+        def get3cf(d):
+            for n, k, _ in data:
+                UnorderedMapStrInt64_Get_Fast(d, n, k, 0)
+
+        def fct3cf():
+            d3cf = UnorderedMapStrInt64_Create()
+            insert3cf(d3cf)
+            get3cf(d3cf)
+
+        def insert3cfrh(d):
+            for n, k, v in data:
+                UnorderedMapRHStrInt64_Insert_Fast(d, n, k, v)
+
+        def get3cfrh(d):
+            for n, k, _ in data:
+                UnorderedMapRHStrInt64_Get_Fast(d, n, k, 0)
+
+        def fct3cfrh():
+            d3cfrh = UnorderedMapRHStrInt64_Create()
+            insert3cfrh(d3cfrh)
+            get3cfrh(d3cfrh)
+
         def fctN(N=4000):
             for _ in range(N):
                 fct1()
                 fct11()
                 fct2()
+                fct3()
+                fct3c()
+                fct3cf()
+                fct3cfrh()
 
         data = [("*" * (i // 2), i, i) for i in range(0, 100)]
 

--- a/_unittests/ut_fastdata/test_fast_dict.py
+++ b/_unittests/ut_fastdata/test_fast_dict.py
@@ -1,0 +1,244 @@
+# pylint: disable=E0611
+"""
+@brief      test log(time=5s)
+"""
+import unittest
+import os
+from pyquickhelper.pycode import ExtTestCase
+from cpyquickhelper.fastdata.fast_dict import (
+    FastDictStrInt64, FastDictInt64Int64, FastDictIntInt)
+from cpyquickhelper.fastdata.fast_dict_cpy import cmap_int_int
+from cpyquickhelper import __file__ as rootfile
+
+
+class TestFastDict(ExtTestCase):
+
+    def test_fast_dict_str(self):
+        keys = [('A', 6, 7), ('ghhj', 7, 8)]
+        d1 = {}
+        d2 = FastDictStrInt64()
+        for name, key, value in keys:
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert(name, key, value)
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get(name, key, 0), value)
+
+    def test_fast_dict_int64(self):
+        keys = [(2, 6, 7), (3, 7, 8)]
+        d1 = {}
+        d2 = FastDictInt64Int64()
+        for name, key, value in keys:
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert(name, key, value)
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get(name, key, 0), value)
+
+    def test_fast_dict_int(self):
+        keys = [(2, 6, 7), (3, 7, 8)]
+        d1 = {}
+        d2 = FastDictIntInt()
+        for name, key, value in keys:
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert(name, key, value)
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get(name, key, 0), value)
+
+    def test_fast_dict_int_cpy(self):
+        keys = [(2, 6, 7), (3, 7, 8)]
+        d1 = {}
+        d2 = cmap_int_int()
+        for name, key, value in keys:
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), 0)
+            self.assertEqual(d2.get(name, key, 0), 0)
+            d1[name, key] = value
+            d2.insert(name, key, value)
+            self.assertEqual(len(d1), len(d2))
+            self.assertEqual(d1.get((name, key), 0), value)
+            self.assertEqual(d2.get(name, key, 0), value)
+
+    def test_profile_str(self):
+
+        def insert1(d):
+            for n, k, v in data:
+                d[n, k] = v
+
+        def insert11(d):
+            for n, k, v in data:
+                if k in d:
+                    d[k][n] = v
+                else:
+                    d[k] = {n: v}
+
+        def insert2(d):
+            for n, k, v in data:
+                d.insert(n, k, v)
+
+        def g1(d, n, k, v):
+            return d.get((n, k), 0)
+
+        def get1(d):
+            for n, k, v in data:
+                g1(d, n, k, v)
+
+        def g11(d, n, k, v):
+            if k in d:
+                if n in d[k]:
+                    return d[k][n]
+            return v
+
+        def get11(d):
+            for n, k, v in data:
+                g11(d, n, k, v)
+
+        def get2(d):
+            for n, k, _ in data:
+                d.get(n, k, 0)
+
+        def fct1():
+            d1 = {}
+            insert1(d1)
+            get1(d1)
+
+        def fct11():
+            d11 = {}
+            insert11(d11)
+            get11(d11)
+
+        def fct2():
+            d2 = FastDictStrInt64()
+            insert2(d2)
+            get2(d2)
+
+        def fctN(N=4000):
+            for _ in range(N):
+                fct1()
+                fct11()
+                fct2()
+
+        data = [("*" * (i // 2), i, i) for i in range(0, 100)]
+
+        rootrem = os.path.normpath(os.path.abspath(
+            os.path.join(os.path.dirname(rootfile), '..')))
+        ps, res = self.profile(  # pylint: disable=W0632
+            fctN, rootrem=rootrem)
+        res = res.replace('\\', '/')
+        if __name__ == "__main__":
+            print(res)
+        self.assertIn('test_fast_dict.py', res)
+        self.assertNotEmpty(ps)
+
+    def test_profile_int(self):
+
+        def insert1(d):
+            for n, k, v in data:
+                d[n, k] = v
+
+        def insert11(d):
+            for n, k, v in data:
+                if k in d:
+                    d[k][n] = v
+                else:
+                    d[k] = {n: v}
+
+        def insert2(d):
+            for n, k, v in data:
+                d.insert(n, k, v)
+
+        def g1(d, n, k, v):
+            return d.get((n, k), 0)
+
+        def get1(d):
+            for n, k, v in data:
+                g1(d, n, k, v)
+
+        def g11(d, n, k, v):
+            if k in d:
+                if n in d[k]:
+                    return d[k][n]
+            return v
+
+        def get11(d):
+            for n, k, v in data:
+                g11(d, n, k, v)
+
+        def get2(d):
+            for n, k, _ in data:
+                d.get(n, k, 0)
+
+        def fct1():
+            d1 = {}
+            insert1(d1)
+            get1(d1)
+
+        def fct11():
+            d11 = {}
+            insert11(d11)
+            get11(d11)
+
+        def fct2():
+            d2 = FastDictInt64Int64()
+            insert2(d2)
+            get2(d2)
+
+        def insert3(d):
+            for n, k, v in data:
+                d.insert(n, k, v)
+
+        def get3(d):
+            for n, k, _ in data:
+                d.get(n, k, 0)
+
+        def fct3():
+            d3 = cmap_int_int()
+            insert3(d3)
+            get3(d3)
+
+        def insert4(d):
+            for n, k, v in data:
+                d.insert(n, k, v)
+
+        def get4(d):
+            for n, k, _ in data:
+                d.get(n, k, 0)
+
+        def fct4():
+            d4 = FastDictIntInt()
+            insert4(d4)
+            get4(d4)
+
+        def fctN(N=4000):
+            for _ in range(N):
+                fct1()
+                fct11()
+                fct2()
+                fct3()
+                fct4()
+
+        data = [(i * 55, i, i) for i in range(0, 100)]
+
+        rootrem = os.path.normpath(os.path.abspath(
+            os.path.join(os.path.dirname(rootfile), '..')))
+        ps, res = self.profile(  # pylint: disable=W0632
+            fctN, rootrem=rootrem)
+        res = res.replace('\\', '/')
+        if __name__ == "__main__":
+            print(res)
+        self.assertIn('test_fast_dict.py', res)
+        self.assertNotEmpty(ps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_unittests/ut_io/test_output_capture.py
+++ b/_unittests/ut_io/test_output_capture.py
@@ -7,8 +7,6 @@ import unittest
 from inspect import signature, isbuiltin, isfunction, _signature_fromstr, Signature
 from pyquickhelper.pycode import ExtTestCase, skipif_appveyor
 from pyquickhelper.helpgen import rst2html
-from pyquickhelper.sphinxext.import_object_helper import (
-    import_any_object, import_object)
 import cpyquickhelper
 from cpyquickhelper.io.stdhelper import capture_output
 from cpyquickhelper.io.stdchelper import cprint  # pylint: disable=E0611
@@ -108,6 +106,8 @@ class TestOutputCapture(ExtTestCase):
 
     @skipif_appveyor("Miktex is not installed.")
     def test_signature(self):
+        from pyquickhelper.sphinxext.import_object_helper import (
+            import_any_object, import_object)
         self.assertRaise(lambda: signature(cprint), ValueError)
         self.assertTrue(isbuiltin(cprint))
         self.assertFalse(isfunction(cprint))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
     displayName: 'Platform'
   - script: python -u setup.py build_ext --inplace
     displayName: 'Build inplace'
-  - script: python -u setup.py unittests
+  - script: python -u setup.py unittests -d 5
     displayName: 'Runs Unit Tests'
   - script: |
       python -m pip install cibuildwheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
-  - script: python -m pip install --upgrade pip setuptools wheel
+  - script: python -m pip install --upgrade pip setuptools wheel pytest
     displayName: 'Install tools'
   - script: pip install -r requirements.txt
     displayName: 'Install Requirements'
@@ -82,7 +82,7 @@ jobs:
     displayName: 'Platform'
   - script: python -u setup.py build_ext --inplace
     displayName: 'Build inplace'
-  - script: python -u setup.py unittests -d 5
+  - script: pytest _unittests
     displayName: 'Runs Unit Tests'
   - script: |
       python -m pip install cibuildwheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
     displayName: 'Build inplace'
   - script: python setup.py install
     displayName: 'install the package'
-  - script: pytest _unittests
+  - script: pytest _unittests --ignore-glob=**/test_run_notebooks.py
     displayName: 'Runs Unit Tests'
   - script: |
       python -m pip install cibuildwheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,8 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python310-Windows:
-        python.version: '3.10'
+      Python39-Windows:
+        python.version: '3.9'
     maxParallel: 3
   steps:
   - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,8 @@ jobs:
     displayName: 'Platform'
   - script: python -u setup.py build_ext --inplace
     displayName: 'Build inplace'
+  - script: python setup.py install
+    displayName: 'install the package'
   - script: pytest _unittests
     displayName: 'Runs Unit Tests'
   - script: |

--- a/cpyquickhelper/fastdata/fast_dict.cpp
+++ b/cpyquickhelper/fastdata/fast_dict.cpp
@@ -1,0 +1,103 @@
+#ifndef SKIP_PYTHON
+#include <unordered_map>
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+struct hash_pair {
+    template <typename T1, typename T2>
+    size_t operator()(const std::pair<T1, T2>& p) const {
+        auto hash1 = std::hash<T1>{}(p.first);
+        auto hash2 = std::hash<T2>{}(p.second);
+        return hash1 ^ hash2;
+    }
+};
+
+
+template<typename TK, typename T>
+class PyFastDict {
+    public:
+        PyFastDict() : _map() {}
+        ~PyFastDict() {}
+        const T& get(const TK& name, const int64_t& key, const T& default_value) const {
+            auto it = _map.find(std::pair<int64_t, TK>(key, name));
+            return (it == _map.end()) ? default_value : it->second;
+        }
+        void insert(const TK& name, const int64_t& key, const T& value) {
+            _map[std::pair<int64_t, TK>(key, name)] = value;
+        }
+        size_t size() const { return _map.size() ; }
+
+    protected:
+        std::unordered_map<std::pair<int64_t, TK>, T, hash_pair> _map;
+};
+
+
+class PyFastDictStrInt64: public PyFastDict<std::string, int64_t> {
+};
+
+
+class PyFastDictInt64Int64: public PyFastDict<int64_t, int64_t> {
+};
+
+
+class PyFastDictIntInt: public PyFastDict<int, int> {
+};
+
+
+PYBIND11_MODULE(fast_dict, m) {
+	m.doc() = "Implements faster dictionaries for specific cases.";
+
+	py::class_<PyFastDictStrInt64> c1 (m, "FastDictStrInt64", 
+    #if defined(__APPLE__)
+    "Dictionary `{ str, int64: int64 }`, faster than the python version."
+    #else
+    R"pbdoc(Dictionary `{ str, int64: int64 }, faster than the python version.`.
+)pbdoc"
+    #endif
+        );
+	c1.def(py::init<>(), "Constructor");
+    c1.def("__len__", &PyFastDictStrInt64::size,
+           "Returns the number of stored elements.");
+    c1.def("get", &PyFastDictStrInt64::get,
+           R"pbdoc("Returns an integer indexed by `name,key`.)pbdoc");
+    c1.def("insert", &PyFastDictStrInt64::insert,
+           R"pbdoc("Inserts an integer indexed by `name,key`.)pbdoc");
+
+	py::class_<PyFastDictInt64Int64> c2 (m, "FastDictInt64Int64", 
+    #if defined(__APPLE__)
+    "Dictionary `{ int64, int64: int64 }`, faster than the python version."
+    #else
+    R"pbdoc(Dictionary `{ int64, int64: int64 }, faster than the python version.`.
+)pbdoc"
+    #endif
+        );
+	c2.def(py::init<>(), "Constructor");
+    c2.def("__len__", &PyFastDictInt64Int64::size,
+           "Returns the number of stored elements.");
+    c2.def("get", &PyFastDictInt64Int64::get,
+           R"pbdoc("Returns an integer indexed by `name,key`.)pbdoc");
+    c2.def("insert", &PyFastDictInt64Int64::insert,
+           R"pbdoc("Inserts an integer indexed by `name,key`.)pbdoc");
+
+	py::class_<PyFastDictIntInt> c3 (m, "FastDictIntInt", 
+    #if defined(__APPLE__)
+    "Dictionary `{ int, int: int }`, faster than the python version."
+    #else
+    R"pbdoc(Dictionary `{ int64, int64: int64 }, faster than the python version.`.
+)pbdoc"
+    #endif
+        );
+	c3.def(py::init<>(), "Constructor");
+    c3.def("__len__", &PyFastDictIntInt::size,
+           "Returns the number of stored elements.");
+    c3.def("get", &PyFastDictIntInt::get,
+           R"pbdoc("Returns an integer indexed by `name,key`.)pbdoc");
+    c3.def("insert", &PyFastDictIntInt::insert,
+           R"pbdoc("Inserts an integer indexed by `name,key`.)pbdoc");
+}
+
+#endif

--- a/cpyquickhelper/fastdata/fast_dict_c.cpp
+++ b/cpyquickhelper/fastdata/fast_dict_c.cpp
@@ -1,0 +1,309 @@
+#include "Python.h"
+#include "frameobject.h"
+#include "robinhood.h"
+#include <unordered_map>
+#include <iostream>
+
+
+struct hash_pair {
+    template <typename T1, typename T2>
+    size_t operator()(const std::pair<T1, T2>& p) const {
+        auto hash1 = std::hash<T1>{}(p.first);
+        auto hash2 = std::hash<T2>{}(p.second);
+        return hash1 ^ hash2;
+    }
+};
+
+
+template<typename TK, typename T>
+class PyFastDict {
+    public:
+        PyFastDict() : _map() {}
+        ~PyFastDict() {}
+        inline const T& get(const TK& name, const int64_t& key, const T& default_value) const {
+            auto it = _map.find(std::pair<int64_t, TK>(key, name));
+            return (it == _map.end()) ? default_value : it->second;
+        }
+        inline void insert(const TK& name, const int64_t& key, const T& value) {
+            _map[std::pair<int64_t, TK>(key, name)] = value;
+        }
+        size_t size() const { return _map.size() ; }
+
+    protected:
+        std::unordered_map<std::pair<int64_t, TK>, T, hash_pair> _map;
+};
+
+
+class PyFastDictStrInt64: public PyFastDict<std::string, int64_t> {
+};
+
+
+struct hash_pair_rh {
+    template <typename T1, typename T2>
+    size_t operator()(const std::pair<T1, T2>& p) const {
+        auto hash1 = robin_hood::hash<T1>{}(p.first);
+        auto hash2 = robin_hood::hash<T2>{}(p.second);
+        return hash1 ^ hash2;
+    }
+};
+
+
+template<typename TK, typename T>
+class PyFastDictRH {
+    public:
+        PyFastDictRH() : _map() {}
+        ~PyFastDictRH() {}
+        inline const T& get(const TK& name, const int64_t& key, const T& default_value) const {
+            auto it = _map.find(std::pair<int64_t, TK>(key, name));
+            return (it == _map.end()) ? default_value : it->second;
+        }
+        inline void insert(const TK& name, const int64_t& key, const T& value) {
+            _map[std::pair<int64_t, TK>(key, name)] = value;
+        }
+        size_t size() const { return _map.size() ; }
+
+    protected:
+        robin_hood::unordered_flat_map<std::pair<int64_t, TK>, T, hash_pair_rh> _map;
+};
+
+
+class PyFastDictRHStrInt64: public PyFastDictRH<std::string, int64_t> {
+};
+
+
+// See https://docs.python.org/3/c-api/stable.html#contents-of-limited-api.
+
+void UnorderedMapStrInt64_Destructor(PyObject *caps) {
+    PyFastDictStrInt64* ptr = (PyFastDictStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return;
+    }
+    delete ptr;
+}
+
+
+PyObject* UnorderedMapStrInt64_Create(PyObject* Py_UNUSED(self), PyObject* args) {
+    auto * obj = new PyFastDictStrInt64();
+    return PyCapsule_New(obj, "UnorderedMapStrInt64", &UnorderedMapStrInt64_Destructor);
+}
+
+
+void UnorderedMapRHStrInt64_Destructor(PyObject *caps) {
+    PyFastDictRHStrInt64* ptr = (PyFastDictRHStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapRHStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return;
+    }
+    delete ptr;
+}
+
+
+PyObject* UnorderedMapRHStrInt64_Create(PyObject* Py_UNUSED(self), PyObject* args) {
+    auto * obj = new PyFastDictRHStrInt64();
+    return PyCapsule_New(obj, "UnorderedMapRHStrInt64", &UnorderedMapRHStrInt64_Destructor);
+}
+
+
+PyObject* UnorderedMapStrInt64_Insert(PyObject* Py_UNUSED(self), PyObject* args) {
+    PyObject* caps;
+    const char* name;
+    int64_t key, value;
+    if(!PyArg_ParseTuple(args, "OsLL", &caps, &name, &key, &value)) {
+        PyErr_SetString(
+            PyExc_TypeError, "Unable to decode the parameters. (capsule, str, int64, int64) are expected.");
+        return 0;
+    }
+
+    PyFastDictStrInt64* ptr = (PyFastDictStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return 0;
+    }
+    
+    ptr->insert(name, key, value);
+    Py_RETURN_NONE;
+}
+
+
+PyObject* UnorderedMapStrInt64_Get(PyObject* Py_UNUSED(self), PyObject* args) {
+    PyObject* caps;
+    const char* name;
+    int64_t key, value;
+    if(!PyArg_ParseTuple(args, "OsLL", &caps, &name, &key, &value)) {
+        PyErr_SetString(
+            PyExc_TypeError, "Unable to decode the parameters. (capsule, str, int64, int64) are expected.");
+        return 0;
+    }
+
+    PyFastDictStrInt64* ptr = (PyFastDictStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return 0;
+    }
+    
+    int64_t res = ptr->get(name, key, value);
+    PyGILState_STATE state = PyGILState_Ensure();
+    PyObject* obj = PyLong_FromLongLong(res);
+    PyGILState_Release(state);
+    
+    return obj;
+}
+
+
+PyObject* UnorderedMapStrInt64_Insert_Fast(PyObject* Py_UNUSED(self), PyObject *const *args, Py_ssize_t nargs) {
+    if (nargs != 4) {
+        PyErr_SetString(
+            PyExc_TypeError, "Unable to decode the parameters. (capsule, str, int64, int64) are expected.");
+        return 0;
+    }
+    PyObject* caps = args[0];
+    const char* name = PyUnicode_AsUTF8(args[1]);
+    int64_t key = PyLong_AsLongLong(args[2]);
+    int64_t value = PyLong_AsLongLong(args[3]);
+
+    PyFastDictStrInt64* ptr = (PyFastDictStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return 0;
+    }
+    
+    ptr->insert(name, key, value);
+    Py_RETURN_NONE;
+}
+
+
+PyObject* UnorderedMapStrInt64_Get_Fast(PyObject* Py_UNUSED(self), PyObject *const *args, Py_ssize_t nargs) {
+    if (nargs != 4) {
+        PyErr_SetString(
+            PyExc_TypeError, "Unable to decode the parameters. (capsule, str, int64, int64) are expected.");
+        return 0;
+    }
+    PyObject* caps = args[0];
+    const char* name = PyUnicode_AsUTF8(args[1]);
+    int64_t key = PyLong_AsLongLong(args[2]);
+    int64_t value = PyLong_AsLongLong(args[3]);
+
+    PyFastDictStrInt64* ptr = (PyFastDictStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return 0;
+    }
+    
+    int64_t res = ptr->get(name, key, value);
+    PyGILState_STATE state = PyGILState_Ensure();
+    PyObject* obj = PyLong_FromLongLong(res);
+    PyGILState_Release(state);
+    
+    return obj;
+}
+
+
+PyObject* UnorderedMapRHStrInt64_Insert_Fast(PyObject* Py_UNUSED(self), PyObject *const *args, Py_ssize_t nargs) {
+    if (nargs != 4) {
+        PyErr_SetString(
+            PyExc_TypeError, "Unable to decode the parameters. (capsule, str, int64, int64) are expected.");
+        return 0;
+    }
+    PyObject* caps = args[0];
+    const char* name = PyUnicode_AsUTF8(args[1]);
+    int64_t key = PyLong_AsLongLong(args[2]);
+    int64_t value = PyLong_AsLongLong(args[3]);
+
+    PyFastDictRHStrInt64* ptr = (PyFastDictRHStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapRHStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return 0;
+    }
+    
+    ptr->insert(name, key, value);
+    Py_RETURN_NONE;
+}
+
+
+PyObject* UnorderedMapRHStrInt64_Get_Fast(PyObject* Py_UNUSED(self), PyObject *const *args, Py_ssize_t nargs) {
+    if (nargs != 4) {
+        PyErr_SetString(
+            PyExc_TypeError, "Unable to decode the parameters. (capsule, str, int64, int64) are expected.");
+        return 0;
+    }
+    PyObject* caps = args[0];
+    const char* name = PyUnicode_AsUTF8(args[1]);
+    int64_t key = PyLong_AsLongLong(args[2]);
+    int64_t value = PyLong_AsLongLong(args[3]);
+
+    PyFastDictRHStrInt64* ptr = (PyFastDictRHStrInt64*)PyCapsule_GetPointer(caps, "UnorderedMapRHStrInt64");
+    if (ptr == 0) {
+        PyErr_SetString(PyExc_ValueError, "Capsule pointer is null.");
+        return 0;
+    }
+    
+    int64_t res = ptr->get(name, key, value);
+    PyGILState_STATE state = PyGILState_Ensure();
+    PyObject* obj = PyLong_FromLongLong(res);
+    PyGILState_Release(state);
+    
+    return obj;
+}
+
+
+static PyMethodDef module_methods[] = {
+    {"UnorderedMapStrInt64_Create", UnorderedMapStrInt64_Create, METH_NOARGS,
+        "Creates an unordered map `{ (str, int): int }`."},
+    {"UnorderedMapRHStrInt64_Create", UnorderedMapRHStrInt64_Create, METH_NOARGS,
+        "Creates a faster unordered map `{ (str, int): int }`.\\n"
+        "This map is using `robin_hood implementation "
+        "<https://github.com/martinus/robin-hood-hashing>`_."},
+    {"UnorderedMapStrInt64_Insert", UnorderedMapStrInt64_Insert, METH_VARARGS,
+        "Inserts a value into a map `{ (str, int): int }`"
+        ":param obj: unordered_map\n"
+        ":param name: str\n"
+        ":param key: int\n"
+        ":param value: int"},
+    {"UnorderedMapStrInt64_Insert_Fast", (PyCFunction)UnorderedMapStrInt64_Insert_Fast, METH_FASTCALL,
+        "Inserts a value into a map `{ (str, int): int }`"
+        ":param obj: unordered_map\n"
+        ":param name: str\n"
+        ":param key: int\n"
+        ":param value: int"},
+    {"UnorderedMapRHStrInt64_Insert_Fast", (PyCFunction)UnorderedMapRHStrInt64_Insert_Fast, METH_FASTCALL,
+        "Inserts a value into a map `{ (str, int): int }`"
+        ":param obj: unordered_map\n"
+        ":param name: str\n"
+        ":param key: int\n"
+        ":param value: int"},
+    {"UnorderedMapStrInt64_Get", UnorderedMapStrInt64_Get, METH_VARARGS,
+        "Inserts a value into a map `{ (str, int): int }`"
+        ":param obj: unordered_map\n"
+        ":param name: str\n"
+        ":param key: int\n"
+        ":param value: int\n"
+        ":return: int"},
+    {"UnorderedMapStrInt64_Get_Fast", (PyCFunction)UnorderedMapStrInt64_Get_Fast, METH_FASTCALL,
+        "Inserts a value into a map `{ (str, int): int }`"
+        ":param obj: unordered_map\n"
+        ":param name: str\n"
+        ":param key: int\n"
+        ":param value: int\n"
+        ":return: int"},
+    {"UnorderedMapRHStrInt64_Get_Fast", (PyCFunction)UnorderedMapRHStrInt64_Get_Fast, METH_FASTCALL,
+        "Inserts a value into a map `{ (str, int): int }`"
+        ":param obj: unordered_map\n"
+        ":param name: str\n"
+        ":param key: int\n"
+        ":param value: int\n"
+        ":return: int"},
+        
+    {0, 0, 0, 0} // End of list
+};
+
+
+PyMODINIT_FUNC
+PyInit_fast_dict_c(void) {
+    static struct PyModuleDef theModuleDef = {
+        PyModuleDef_HEAD_INIT, "fast_dict_c",
+        "Fast dictionary using Python C API.",
+        -1, module_methods, 0, 0, 0, 0 };
+    PyObject* m = PyModule_Create(&theModuleDef);
+    return m;
+}

--- a/cpyquickhelper/fastdata/fast_dict_cpy.pyx
+++ b/cpyquickhelper/fastdata/fast_dict_cpy.pyx
@@ -1,0 +1,30 @@
+"""
+@file
+@brief Implements fast dictionaries with :epkg:`cython` in a specific case.
+"""
+from cython.operator cimport dereference
+from libcpp.pair cimport pair
+from libcpp.map cimport map as cmap
+
+
+ctypedef cmap[pair[int, int], int] cpp_cmap_type
+
+
+cdef class cmap_int_int:
+
+    cdef cpp_cmap_type container
+
+    def __cinit__(self):
+        self.container = cpp_cmap_type()
+
+    def get(self, int name, int key, int default_value):
+        it = self.container.find(pair[int, int](key, name))
+        if it == self.container.end():
+            return default_value
+        return dereference(it).second
+
+    def insert(self, int name, int key, int value):
+        self.container.insert(pair[pair[int, int], int](pair[int, int](key, name), value))
+
+    def __len__(self):
+        return self.container.size()

--- a/cpyquickhelper/fastdata/robinhood.h
+++ b/cpyquickhelper/fastdata/robinhood.h
@@ -1,0 +1,2545 @@
+//                 ______  _____                 ______                _________
+//  ______________ ___  /_ ___(_)_______         ___  /_ ______ ______ ______  /
+//  __  ___/_  __ \__  __ \__  / __  __ \        __  __ \_  __ \_  __ \_  __  /
+//  _  /    / /_/ /_  /_/ /_  /  _  / / /        _  / / // /_/ // /_/ // /_/ /
+//  /_/     \____/ /_.___/ /_/   /_/ /_/ ________/_/ /_/ \____/ \____/ \__,_/
+//                                      _/_____/
+//
+// Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20
+// https://github.com/martinus/robin-hood-hashing
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2021 Martin Ankerl <http://martin.ankerl.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ROBIN_HOOD_H_INCLUDED
+#define ROBIN_HOOD_H_INCLUDED
+
+// see https://semver.org/
+#define ROBIN_HOOD_VERSION_MAJOR 3  // for incompatible API changes
+#define ROBIN_HOOD_VERSION_MINOR 11 // for adding functionality in a backwards-compatible manner
+#define ROBIN_HOOD_VERSION_PATCH 4  // for backwards-compatible bug fixes
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory> // only to support hash of smart pointers
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#if __cplusplus >= 201703L
+#    include <string_view>
+#endif
+
+// #define ROBIN_HOOD_LOG_ENABLED
+#ifdef ROBIN_HOOD_LOG_ENABLED
+#    include <iostream>
+#    define ROBIN_HOOD_LOG(...) \
+        std::cout << __FUNCTION__ << "@" << __LINE__ << ": " << __VA_ARGS__ << std::endl;
+#else
+#    define ROBIN_HOOD_LOG(x)
+#endif
+
+// #define ROBIN_HOOD_TRACE_ENABLED
+#ifdef ROBIN_HOOD_TRACE_ENABLED
+#    include <iostream>
+#    define ROBIN_HOOD_TRACE(...) \
+        std::cout << __FUNCTION__ << "@" << __LINE__ << ": " << __VA_ARGS__ << std::endl;
+#else
+#    define ROBIN_HOOD_TRACE(x)
+#endif
+
+// #define ROBIN_HOOD_COUNT_ENABLED
+#ifdef ROBIN_HOOD_COUNT_ENABLED
+#    include <iostream>
+#    define ROBIN_HOOD_COUNT(x) ++counts().x;
+namespace robin_hood {
+struct Counts {
+    uint64_t shiftUp{};
+    uint64_t shiftDown{};
+};
+inline std::ostream& operator<<(std::ostream& os, Counts const& c) {
+    return os << c.shiftUp << " shiftUp" << std::endl << c.shiftDown << " shiftDown" << std::endl;
+}
+
+static Counts& counts() {
+    static Counts counts{};
+    return counts;
+}
+} // namespace robin_hood
+#else
+#    define ROBIN_HOOD_COUNT(x)
+#endif
+
+// all non-argument macros should use this facility. See
+// https://www.fluentcpp.com/2019/05/28/better-macros-better-flags/
+#define ROBIN_HOOD(x) ROBIN_HOOD_PRIVATE_DEFINITION_##x()
+
+// mark unused members with this macro
+#define ROBIN_HOOD_UNUSED(identifier)
+
+// bitness
+#if SIZE_MAX == UINT32_MAX
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BITNESS() 32
+#elif SIZE_MAX == UINT64_MAX
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BITNESS() 64
+#else
+#    error Unsupported bitness
+#endif
+
+// endianess
+#ifdef _MSC_VER
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_LITTLE_ENDIAN() 1
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BIG_ENDIAN() 0
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_LITTLE_ENDIAN() \
+        (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BIG_ENDIAN() (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#endif
+
+// inline
+#ifdef _MSC_VER
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NOINLINE() __declspec(noinline)
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NOINLINE() __attribute__((noinline))
+#endif
+
+// exceptions
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_EXCEPTIONS() 0
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_EXCEPTIONS() 1
+#endif
+
+// count leading/trailing bits
+#if !defined(ROBIN_HOOD_DISABLE_INTRINSICS)
+#    ifdef _MSC_VER
+#        if ROBIN_HOOD(BITNESS) == 32
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD() _BitScanForward
+#        else
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD() _BitScanForward64
+#        endif
+#        include <intrin.h>
+#        pragma intrinsic(ROBIN_HOOD(BITSCANFORWARD))
+#        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x)                                       \
+            [](size_t mask) noexcept -> int {                                             \
+                unsigned long index;                                                      \
+                return ROBIN_HOOD(BITSCANFORWARD)(&index, mask) ? static_cast<int>(index) \
+                                                                : ROBIN_HOOD(BITNESS);    \
+            }(x)
+#    else
+#        if ROBIN_HOOD(BITNESS) == 32
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ() __builtin_ctzl
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CLZ() __builtin_clzl
+#        else
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ() __builtin_ctzll
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CLZ() __builtin_clzll
+#        endif
+#        define ROBIN_HOOD_COUNT_LEADING_ZEROES(x) ((x) ? ROBIN_HOOD(CLZ)(x) : ROBIN_HOOD(BITNESS))
+#        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x) ((x) ? ROBIN_HOOD(CTZ)(x) : ROBIN_HOOD(BITNESS))
+#    endif
+#endif
+
+// fallthrough
+#ifndef __has_cpp_attribute // For backwards compatibility
+#    define __has_cpp_attribute(x) 0
+#endif
+#if __has_cpp_attribute(clang::fallthrough)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH() [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH() [[gnu::fallthrough]]
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH()
+#endif
+
+// likely/unlikely
+#ifdef _MSC_VER
+#    define ROBIN_HOOD_LIKELY(condition) condition
+#    define ROBIN_HOOD_UNLIKELY(condition) condition
+#else
+#    define ROBIN_HOOD_LIKELY(condition) __builtin_expect(condition, 1)
+#    define ROBIN_HOOD_UNLIKELY(condition) __builtin_expect(condition, 0)
+#endif
+
+// detect if native wchar_t type is availiable in MSVC
+#ifdef _MSC_VER
+#    ifdef _NATIVE_WCHAR_T_DEFINED
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 1
+#    else
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 0
+#    endif
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 1
+#endif
+
+// detect if MSVC supports the pair(std::piecewise_construct_t,...) consructor being constexpr
+#ifdef _MSC_VER
+#    if _MSC_VER <= 1900
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 1
+#    else
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
+#    endif
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
+#endif
+
+// workaround missing "is_trivially_copyable" in g++ < 5.0
+// See https://stackoverflow.com/a/31798726/48181
+#if defined(__GNUC__) && __GNUC__ < 5
+#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
+#else
+#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
+#endif
+
+// helpers for C++ versions, see https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX() __cplusplus
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX98() 199711L
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX11() 201103L
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX14() 201402L
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX17() 201703L
+
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX17)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD() [[nodiscard]]
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD()
+#endif
+
+namespace robin_hood {
+
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX14)
+#    define ROBIN_HOOD_STD std
+#else
+
+// c++11 compatibility layer
+namespace ROBIN_HOOD_STD {
+template <class T>
+struct alignment_of
+    : std::integral_constant<std::size_t, alignof(typename std::remove_all_extents<T>::type)> {};
+
+template <class T, T... Ints>
+class integer_sequence {
+public:
+    using value_type = T;
+    static_assert(std::is_integral<value_type>::value, "not integral type");
+    static constexpr std::size_t size() noexcept {
+        return sizeof...(Ints);
+    }
+};
+template <std::size_t... Inds>
+using index_sequence = integer_sequence<std::size_t, Inds...>;
+
+namespace detail_ {
+template <class T, T Begin, T End, bool>
+struct IntSeqImpl {
+    using TValue = T;
+    static_assert(std::is_integral<TValue>::value, "not integral type");
+    static_assert(Begin >= 0 && Begin < End, "unexpected argument (Begin<0 || Begin<=End)");
+
+    template <class, class>
+    struct IntSeqCombiner;
+
+    template <TValue... Inds0, TValue... Inds1>
+    struct IntSeqCombiner<integer_sequence<TValue, Inds0...>, integer_sequence<TValue, Inds1...>> {
+        using TResult = integer_sequence<TValue, Inds0..., Inds1...>;
+    };
+
+    using TResult =
+        typename IntSeqCombiner<typename IntSeqImpl<TValue, Begin, Begin + (End - Begin) / 2,
+                                                    (End - Begin) / 2 == 1>::TResult,
+                                typename IntSeqImpl<TValue, Begin + (End - Begin) / 2, End,
+                                                    (End - Begin + 1) / 2 == 1>::TResult>::TResult;
+};
+
+template <class T, T Begin>
+struct IntSeqImpl<T, Begin, Begin, false> {
+    using TValue = T;
+    static_assert(std::is_integral<TValue>::value, "not integral type");
+    static_assert(Begin >= 0, "unexpected argument (Begin<0)");
+    using TResult = integer_sequence<TValue>;
+};
+
+template <class T, T Begin, T End>
+struct IntSeqImpl<T, Begin, End, true> {
+    using TValue = T;
+    static_assert(std::is_integral<TValue>::value, "not integral type");
+    static_assert(Begin >= 0, "unexpected argument (Begin<0)");
+    using TResult = integer_sequence<TValue, Begin>;
+};
+} // namespace detail_
+
+template <class T, T N>
+using make_integer_sequence = typename detail_::IntSeqImpl<T, 0, N, (N - 0) == 1>::TResult;
+
+template <std::size_t N>
+using make_index_sequence = make_integer_sequence<std::size_t, N>;
+
+template <class... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
+} // namespace ROBIN_HOOD_STD
+
+#endif
+
+namespace detail {
+
+// make sure we static_cast to the correct type for hash_int
+#if ROBIN_HOOD(BITNESS) == 64
+using SizeT = uint64_t;
+#else
+using SizeT = uint32_t;
+#endif
+
+template <typename T>
+T rotr(T x, unsigned k) {
+    return (x >> k) | (x << (8U * sizeof(T) - k));
+}
+
+// This cast gets rid of warnings like "cast from 'uint8_t*' {aka 'unsigned char*'} to
+// 'uint64_t*' {aka 'long unsigned int*'} increases required alignment of target type". Use with
+// care!
+template <typename T>
+inline T reinterpret_cast_no_cast_align_warning(void* ptr) noexcept {
+    return reinterpret_cast<T>(ptr);
+}
+
+template <typename T>
+inline T reinterpret_cast_no_cast_align_warning(void const* ptr) noexcept {
+    return reinterpret_cast<T>(ptr);
+}
+
+// make sure this is not inlined as it is slow and dramatically enlarges code, thus making other
+// inlinings more difficult. Throws are also generally the slow path.
+template <typename E, typename... Args>
+[[noreturn]] ROBIN_HOOD(NOINLINE)
+#if ROBIN_HOOD(HAS_EXCEPTIONS)
+    void doThrow(Args&&... args) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+    throw E(std::forward<Args>(args)...);
+}
+#else
+    void doThrow(Args&&... ROBIN_HOOD_UNUSED(args) /*unused*/) {
+    abort();
+}
+#endif
+
+template <typename E, typename T, typename... Args>
+T* assertNotNull(T* t, Args&&... args) {
+    if (ROBIN_HOOD_UNLIKELY(nullptr == t)) {
+        doThrow<E>(std::forward<Args>(args)...);
+    }
+    return t;
+}
+
+template <typename T>
+inline T unaligned_load(void const* ptr) noexcept {
+    // using memcpy so we don't get into unaligned load problems.
+    // compiler should optimize this very well anyways.
+    T t;
+    std::memcpy(&t, ptr, sizeof(T));
+    return t;
+}
+
+// Allocates bulks of memory for objects of type T. This deallocates the memory in the destructor,
+// and keeps a linked list of the allocated memory around. Overhead per allocation is the size of a
+// pointer.
+template <typename T, size_t MinNumAllocs = 4, size_t MaxNumAllocs = 256>
+class BulkPoolAllocator {
+public:
+    BulkPoolAllocator() noexcept = default;
+
+    // does not copy anything, just creates a new allocator.
+    BulkPoolAllocator(const BulkPoolAllocator& ROBIN_HOOD_UNUSED(o) /*unused*/) noexcept
+        : mHead(nullptr)
+        , mListForFree(nullptr) {}
+
+    BulkPoolAllocator(BulkPoolAllocator&& o) noexcept
+        : mHead(o.mHead)
+        , mListForFree(o.mListForFree) {
+        o.mListForFree = nullptr;
+        o.mHead = nullptr;
+    }
+
+    BulkPoolAllocator& operator=(BulkPoolAllocator&& o) noexcept {
+        reset();
+        mHead = o.mHead;
+        mListForFree = o.mListForFree;
+        o.mListForFree = nullptr;
+        o.mHead = nullptr;
+        return *this;
+    }
+
+    BulkPoolAllocator&
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
+    operator=(const BulkPoolAllocator& ROBIN_HOOD_UNUSED(o) /*unused*/) noexcept {
+        // does not do anything
+        return *this;
+    }
+
+    ~BulkPoolAllocator() noexcept {
+        reset();
+    }
+
+    // Deallocates all allocated memory.
+    void reset() noexcept {
+        while (mListForFree) {
+            T* tmp = *mListForFree;
+            ROBIN_HOOD_LOG("std::free")
+            std::free(mListForFree);
+            mListForFree = reinterpret_cast_no_cast_align_warning<T**>(tmp);
+        }
+        mHead = nullptr;
+    }
+
+    // allocates, but does NOT initialize. Use in-place new constructor, e.g.
+    //   T* obj = pool.allocate();
+    //   ::new (static_cast<void*>(obj)) T();
+    T* allocate() {
+        T* tmp = mHead;
+        if (!tmp) {
+            tmp = performAllocation();
+        }
+
+        mHead = *reinterpret_cast_no_cast_align_warning<T**>(tmp);
+        return tmp;
+    }
+
+    // does not actually deallocate but puts it in store.
+    // make sure you have already called the destructor! e.g. with
+    //  obj->~T();
+    //  pool.deallocate(obj);
+    void deallocate(T* obj) noexcept {
+        *reinterpret_cast_no_cast_align_warning<T**>(obj) = mHead;
+        mHead = obj;
+    }
+
+    // Adds an already allocated block of memory to the allocator. This allocator is from now on
+    // responsible for freeing the data (with free()). If the provided data is not large enough to
+    // make use of, it is immediately freed. Otherwise it is reused and freed in the destructor.
+    void addOrFree(void* ptr, const size_t numBytes) noexcept {
+        // calculate number of available elements in ptr
+        if (numBytes < ALIGNMENT + ALIGNED_SIZE) {
+            // not enough data for at least one element. Free and return.
+            ROBIN_HOOD_LOG("std::free")
+            std::free(ptr);
+        } else {
+            ROBIN_HOOD_LOG("add to buffer")
+            add(ptr, numBytes);
+        }
+    }
+
+    void swap(BulkPoolAllocator<T, MinNumAllocs, MaxNumAllocs>& other) noexcept {
+        using std::swap;
+        swap(mHead, other.mHead);
+        swap(mListForFree, other.mListForFree);
+    }
+
+private:
+    // iterates the list of allocated memory to calculate how many to alloc next.
+    // Recalculating this each time saves us a size_t member.
+    // This ignores the fact that memory blocks might have been added manually with addOrFree. In
+    // practice, this should not matter much.
+    ROBIN_HOOD(NODISCARD) size_t calcNumElementsToAlloc() const noexcept {
+        auto tmp = mListForFree;
+        size_t numAllocs = MinNumAllocs;
+
+        while (numAllocs * 2 <= MaxNumAllocs && tmp) {
+            auto x = reinterpret_cast<T***>(tmp);
+            tmp = *x;
+            numAllocs *= 2;
+        }
+
+        return numAllocs;
+    }
+
+    // WARNING: Underflow if numBytes < ALIGNMENT! This is guarded in addOrFree().
+    void add(void* ptr, const size_t numBytes) noexcept {
+        const size_t numElements = (numBytes - ALIGNMENT) / ALIGNED_SIZE;
+
+        auto data = reinterpret_cast<T**>(ptr);
+
+        // link free list
+        auto x = reinterpret_cast<T***>(data);
+        *x = mListForFree;
+        mListForFree = data;
+
+        // create linked list for newly allocated data
+        auto* const headT =
+            reinterpret_cast_no_cast_align_warning<T*>(reinterpret_cast<char*>(ptr) + ALIGNMENT);
+
+        auto* const head = reinterpret_cast<char*>(headT);
+
+        // Visual Studio compiler automatically unrolls this loop, which is pretty cool
+        for (size_t i = 0; i < numElements; ++i) {
+            *reinterpret_cast_no_cast_align_warning<char**>(head + i * ALIGNED_SIZE) =
+                head + (i + 1) * ALIGNED_SIZE;
+        }
+
+        // last one points to 0
+        *reinterpret_cast_no_cast_align_warning<T**>(head + (numElements - 1) * ALIGNED_SIZE) =
+            mHead;
+        mHead = headT;
+    }
+
+    // Called when no memory is available (mHead == 0).
+    // Don't inline this slow path.
+    ROBIN_HOOD(NOINLINE) T* performAllocation() {
+        size_t const numElementsToAlloc = calcNumElementsToAlloc();
+
+        // alloc new memory: [prev |T, T, ... T]
+        size_t const bytes = ALIGNMENT + ALIGNED_SIZE * numElementsToAlloc;
+        ROBIN_HOOD_LOG("std::malloc " << bytes << " = " << ALIGNMENT << " + " << ALIGNED_SIZE
+                                      << " * " << numElementsToAlloc)
+        add(assertNotNull<std::bad_alloc>(std::malloc(bytes)), bytes);
+        return mHead;
+    }
+
+    // enforce byte alignment of the T's
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX14)
+    static constexpr size_t ALIGNMENT =
+        (std::max)(std::alignment_of<T>::value, std::alignment_of<T*>::value);
+#else
+    static const size_t ALIGNMENT =
+        (ROBIN_HOOD_STD::alignment_of<T>::value > ROBIN_HOOD_STD::alignment_of<T*>::value)
+            ? ROBIN_HOOD_STD::alignment_of<T>::value
+            : +ROBIN_HOOD_STD::alignment_of<T*>::value; // the + is for walkarround
+#endif
+
+    static constexpr size_t ALIGNED_SIZE = ((sizeof(T) - 1) / ALIGNMENT + 1) * ALIGNMENT;
+
+    static_assert(MinNumAllocs >= 1, "MinNumAllocs");
+    static_assert(MaxNumAllocs >= MinNumAllocs, "MaxNumAllocs");
+    static_assert(ALIGNED_SIZE >= sizeof(T*), "ALIGNED_SIZE");
+    static_assert(0 == (ALIGNED_SIZE % sizeof(T*)), "ALIGNED_SIZE mod");
+    static_assert(ALIGNMENT >= sizeof(T*), "ALIGNMENT");
+
+    T* mHead{nullptr};
+    T** mListForFree{nullptr};
+};
+
+template <typename T, size_t MinSize, size_t MaxSize, bool IsFlat>
+struct NodeAllocator;
+
+// dummy allocator that does nothing
+template <typename T, size_t MinSize, size_t MaxSize>
+struct NodeAllocator<T, MinSize, MaxSize, true> {
+
+    // we are not using the data, so just free it.
+    void addOrFree(void* ptr, size_t ROBIN_HOOD_UNUSED(numBytes) /*unused*/) noexcept {
+        ROBIN_HOOD_LOG("std::free")
+        std::free(ptr);
+    }
+};
+
+template <typename T, size_t MinSize, size_t MaxSize>
+struct NodeAllocator<T, MinSize, MaxSize, false> : public BulkPoolAllocator<T, MinSize, MaxSize> {};
+
+// c++14 doesn't have is_nothrow_swappable, and clang++ 6.0.1 doesn't like it either, so I'm making
+// my own here.
+namespace swappable {
+#if ROBIN_HOOD(CXX) < ROBIN_HOOD(CXX17)
+using std::swap;
+template <typename T>
+struct nothrow {
+    static const bool value = noexcept(swap(std::declval<T&>(), std::declval<T&>()));
+};
+#else
+template <typename T>
+struct nothrow {
+    static const bool value = std::is_nothrow_swappable<T>::value;
+};
+#endif
+} // namespace swappable
+
+} // namespace detail
+
+struct is_transparent_tag {};
+
+// A custom pair implementation is used in the map because std::pair is not is_trivially_copyable,
+// which means it would  not be allowed to be used in std::memcpy. This struct is copyable, which is
+// also tested.
+template <typename T1, typename T2>
+struct pair {
+    using first_type = T1;
+    using second_type = T2;
+
+    template <typename U1 = T1, typename U2 = T2,
+              typename = typename std::enable_if<std::is_default_constructible<U1>::value &&
+                                                 std::is_default_constructible<U2>::value>::type>
+    constexpr pair() noexcept(noexcept(U1()) && noexcept(U2()))
+        : first()
+        , second() {}
+
+    // pair constructors are explicit so we don't accidentally call this ctor when we don't have to.
+    explicit constexpr pair(std::pair<T1, T2> const& o) noexcept(
+        noexcept(T1(std::declval<T1 const&>())) && noexcept(T2(std::declval<T2 const&>())))
+        : first(o.first)
+        , second(o.second) {}
+
+    // pair constructors are explicit so we don't accidentally call this ctor when we don't have to.
+    explicit constexpr pair(std::pair<T1, T2>&& o) noexcept(noexcept(
+        T1(std::move(std::declval<T1&&>()))) && noexcept(T2(std::move(std::declval<T2&&>()))))
+        : first(std::move(o.first))
+        , second(std::move(o.second)) {}
+
+    constexpr pair(T1&& a, T2&& b) noexcept(noexcept(
+        T1(std::move(std::declval<T1&&>()))) && noexcept(T2(std::move(std::declval<T2&&>()))))
+        : first(std::move(a))
+        , second(std::move(b)) {}
+
+    template <typename U1, typename U2>
+    constexpr pair(U1&& a, U2&& b) noexcept(noexcept(T1(std::forward<U1>(
+        std::declval<U1&&>()))) && noexcept(T2(std::forward<U2>(std::declval<U2&&>()))))
+        : first(std::forward<U1>(a))
+        , second(std::forward<U2>(b)) {}
+
+    template <typename... U1, typename... U2>
+    // MSVC 2015 produces error "C2476: ‘constexpr’ constructor does not initialize all members"
+    // if this constructor is constexpr
+#if !ROBIN_HOOD(BROKEN_CONSTEXPR)
+    constexpr
+#endif
+        pair(std::piecewise_construct_t /*unused*/, std::tuple<U1...> a,
+             std::tuple<U2...>
+                 b) noexcept(noexcept(pair(std::declval<std::tuple<U1...>&>(),
+                                           std::declval<std::tuple<U2...>&>(),
+                                           ROBIN_HOOD_STD::index_sequence_for<U1...>(),
+                                           ROBIN_HOOD_STD::index_sequence_for<U2...>())))
+        : pair(a, b, ROBIN_HOOD_STD::index_sequence_for<U1...>(),
+               ROBIN_HOOD_STD::index_sequence_for<U2...>()) {
+    }
+
+    // constructor called from the std::piecewise_construct_t ctor
+    template <typename... U1, size_t... I1, typename... U2, size_t... I2>
+    pair(std::tuple<U1...>& a, std::tuple<U2...>& b, ROBIN_HOOD_STD::index_sequence<I1...> /*unused*/, ROBIN_HOOD_STD::index_sequence<I2...> /*unused*/) noexcept(
+        noexcept(T1(std::forward<U1>(std::get<I1>(
+            std::declval<std::tuple<
+                U1...>&>()))...)) && noexcept(T2(std::
+                                                     forward<U2>(std::get<I2>(
+                                                         std::declval<std::tuple<U2...>&>()))...)))
+        : first(std::forward<U1>(std::get<I1>(a))...)
+        , second(std::forward<U2>(std::get<I2>(b))...) {
+        // make visual studio compiler happy about warning about unused a & b.
+        // Visual studio's pair implementation disables warning 4100.
+        (void)a;
+        (void)b;
+    }
+
+    void swap(pair<T1, T2>& o) noexcept((detail::swappable::nothrow<T1>::value) &&
+                                        (detail::swappable::nothrow<T2>::value)) {
+        using std::swap;
+        swap(first, o.first);
+        swap(second, o.second);
+    }
+
+    T1 first;  // NOLINT(misc-non-private-member-variables-in-classes)
+    T2 second; // NOLINT(misc-non-private-member-variables-in-classes)
+};
+
+template <typename A, typename B>
+inline void swap(pair<A, B>& a, pair<A, B>& b) noexcept(
+    noexcept(std::declval<pair<A, B>&>().swap(std::declval<pair<A, B>&>()))) {
+    a.swap(b);
+}
+
+template <typename A, typename B>
+inline constexpr bool operator==(pair<A, B> const& x, pair<A, B> const& y) {
+    return (x.first == y.first) && (x.second == y.second);
+}
+template <typename A, typename B>
+inline constexpr bool operator!=(pair<A, B> const& x, pair<A, B> const& y) {
+    return !(x == y);
+}
+template <typename A, typename B>
+inline constexpr bool operator<(pair<A, B> const& x, pair<A, B> const& y) noexcept(noexcept(
+    std::declval<A const&>() < std::declval<A const&>()) && noexcept(std::declval<B const&>() <
+                                                                     std::declval<B const&>())) {
+    return x.first < y.first || (!(y.first < x.first) && x.second < y.second);
+}
+template <typename A, typename B>
+inline constexpr bool operator>(pair<A, B> const& x, pair<A, B> const& y) {
+    return y < x;
+}
+template <typename A, typename B>
+inline constexpr bool operator<=(pair<A, B> const& x, pair<A, B> const& y) {
+    return !(x > y);
+}
+template <typename A, typename B>
+inline constexpr bool operator>=(pair<A, B> const& x, pair<A, B> const& y) {
+    return !(x < y);
+}
+
+inline size_t hash_bytes(void const* ptr, size_t len) noexcept {
+    static constexpr uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
+    static constexpr uint64_t seed = UINT64_C(0xe17a1465);
+    static constexpr unsigned int r = 47;
+
+    auto const* const data64 = static_cast<uint64_t const*>(ptr);
+    uint64_t h = seed ^ (len * m);
+
+    size_t const n_blocks = len / 8;
+    for (size_t i = 0; i < n_blocks; ++i) {
+        auto k = detail::unaligned_load<uint64_t>(data64 + i);
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+    }
+
+    auto const* const data8 = reinterpret_cast<uint8_t const*>(data64 + n_blocks);
+    switch (len & 7U) {
+    case 7:
+        h ^= static_cast<uint64_t>(data8[6]) << 48U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 6:
+        h ^= static_cast<uint64_t>(data8[5]) << 40U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 5:
+        h ^= static_cast<uint64_t>(data8[4]) << 32U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 4:
+        h ^= static_cast<uint64_t>(data8[3]) << 24U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 3:
+        h ^= static_cast<uint64_t>(data8[2]) << 16U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 2:
+        h ^= static_cast<uint64_t>(data8[1]) << 8U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 1:
+        h ^= static_cast<uint64_t>(data8[0]);
+        h *= m;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    default:
+        break;
+    }
+
+    h ^= h >> r;
+
+    // not doing the final step here, because this will be done by keyToIdx anyways
+    // h *= m;
+    // h ^= h >> r;
+    return static_cast<size_t>(h);
+}
+
+inline size_t hash_int(uint64_t x) noexcept {
+    // tried lots of different hashes, let's stick with murmurhash3. It's simple, fast, well tested,
+    // and doesn't need any special 128bit operations.
+    x ^= x >> 33U;
+    x *= UINT64_C(0xff51afd7ed558ccd);
+    x ^= x >> 33U;
+
+    // not doing the final step here, because this will be done by keyToIdx anyways
+    // x *= UINT64_C(0xc4ceb9fe1a85ec53);
+    // x ^= x >> 33U;
+    return static_cast<size_t>(x);
+}
+
+// A thin wrapper around std::hash, performing an additional simple mixing step of the result.
+template <typename T, typename Enable = void>
+struct hash : public std::hash<T> {
+    size_t operator()(T const& obj) const
+        noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const&>()))) {
+        // call base hash
+        auto result = std::hash<T>::operator()(obj);
+        // return mixed of that, to be save against identity has
+        return hash_int(static_cast<detail::SizeT>(result));
+    }
+};
+
+template <typename CharT>
+struct hash<std::basic_string<CharT>> {
+    size_t operator()(std::basic_string<CharT> const& str) const noexcept {
+        return hash_bytes(str.data(), sizeof(CharT) * str.size());
+    }
+};
+
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX17)
+template <typename CharT>
+struct hash<std::basic_string_view<CharT>> {
+    size_t operator()(std::basic_string_view<CharT> const& sv) const noexcept {
+        return hash_bytes(sv.data(), sizeof(CharT) * sv.size());
+    }
+};
+#endif
+
+template <class T>
+struct hash<T*> {
+    size_t operator()(T* ptr) const noexcept {
+        return hash_int(reinterpret_cast<detail::SizeT>(ptr));
+    }
+};
+
+template <class T>
+struct hash<std::unique_ptr<T>> {
+    size_t operator()(std::unique_ptr<T> const& ptr) const noexcept {
+        return hash_int(reinterpret_cast<detail::SizeT>(ptr.get()));
+    }
+};
+
+template <class T>
+struct hash<std::shared_ptr<T>> {
+    size_t operator()(std::shared_ptr<T> const& ptr) const noexcept {
+        return hash_int(reinterpret_cast<detail::SizeT>(ptr.get()));
+    }
+};
+
+template <typename Enum>
+struct hash<Enum, typename std::enable_if<std::is_enum<Enum>::value>::type> {
+    size_t operator()(Enum e) const noexcept {
+        using Underlying = typename std::underlying_type<Enum>::type;
+        return hash<Underlying>{}(static_cast<Underlying>(e));
+    }
+};
+
+#define ROBIN_HOOD_HASH_INT(T)                           \
+    template <>                                          \
+    struct hash<T> {                                     \
+        size_t operator()(T const& obj) const noexcept { \
+            return hash_int(static_cast<uint64_t>(obj)); \
+        }                                                \
+    }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
+// see https://en.cppreference.com/w/cpp/utility/hash
+ROBIN_HOOD_HASH_INT(bool);
+ROBIN_HOOD_HASH_INT(char);
+ROBIN_HOOD_HASH_INT(signed char);
+ROBIN_HOOD_HASH_INT(unsigned char);
+ROBIN_HOOD_HASH_INT(char16_t);
+ROBIN_HOOD_HASH_INT(char32_t);
+#if ROBIN_HOOD(HAS_NATIVE_WCHART)
+ROBIN_HOOD_HASH_INT(wchar_t);
+#endif
+ROBIN_HOOD_HASH_INT(short);
+ROBIN_HOOD_HASH_INT(unsigned short);
+ROBIN_HOOD_HASH_INT(int);
+ROBIN_HOOD_HASH_INT(unsigned int);
+ROBIN_HOOD_HASH_INT(long);
+ROBIN_HOOD_HASH_INT(long long);
+ROBIN_HOOD_HASH_INT(unsigned long);
+ROBIN_HOOD_HASH_INT(unsigned long long);
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic pop
+#endif
+namespace detail {
+
+template <typename T>
+struct void_type {
+    using type = void;
+};
+
+template <typename T, typename = void>
+struct has_is_transparent : public std::false_type {};
+
+template <typename T>
+struct has_is_transparent<T, typename void_type<typename T::is_transparent>::type>
+    : public std::true_type {};
+
+// using wrapper classes for hash and key_equal prevents the diamond problem when the same type
+// is used. see https://stackoverflow.com/a/28771920/48181
+template <typename T>
+struct WrapHash : public T {
+    WrapHash() = default;
+    explicit WrapHash(T const& o) noexcept(noexcept(T(std::declval<T const&>())))
+        : T(o) {}
+};
+
+template <typename T>
+struct WrapKeyEqual : public T {
+    WrapKeyEqual() = default;
+    explicit WrapKeyEqual(T const& o) noexcept(noexcept(T(std::declval<T const&>())))
+        : T(o) {}
+};
+
+// A highly optimized hashmap implementation, using the Robin Hood algorithm.
+//
+// In most cases, this map should be usable as a drop-in replacement for std::unordered_map, but
+// be about 2x faster in most cases and require much less allocations.
+//
+// This implementation uses the following memory layout:
+//
+// [Node, Node, ... Node | info, info, ... infoSentinel ]
+//
+// * Node: either a DataNode that directly has the std::pair<key, val> as member,
+//   or a DataNode with a pointer to std::pair<key,val>. Which DataNode representation to use
+//   depends on how fast the swap() operation is. Heuristically, this is automatically choosen
+//   based on sizeof(). there are always 2^n Nodes.
+//
+// * info: Each Node in the map has a corresponding info byte, so there are 2^n info bytes.
+//   Each byte is initialized to 0, meaning the corresponding Node is empty. Set to 1 means the
+//   corresponding node contains data. Set to 2 means the corresponding Node is filled, but it
+//   actually belongs to the previous position and was pushed out because that place is already
+//   taken.
+//
+// * infoSentinel: Sentinel byte set to 1, so that iterator's ++ can stop at end() without the
+//   need for a idx variable.
+//
+// According to STL, order of templates has effect on throughput. That's why I've moved the
+// boolean to the front.
+// https://www.reddit.com/r/cpp/comments/ahp6iu/compile_time_binary_size_reductions_and_cs_future/eeguck4/
+template <bool IsFlat, size_t MaxLoadFactor100, typename Key, typename T, typename Hash,
+          typename KeyEqual>
+class Table
+    : public WrapHash<Hash>,
+      public WrapKeyEqual<KeyEqual>,
+      detail::NodeAllocator<
+          typename std::conditional<
+              std::is_void<T>::value, Key,
+              robin_hood::pair<typename std::conditional<IsFlat, Key, Key const>::type, T>>::type,
+          4, 16384, IsFlat> {
+public:
+    static constexpr bool is_flat = IsFlat;
+    static constexpr bool is_map = !std::is_void<T>::value;
+    static constexpr bool is_set = !is_map;
+    static constexpr bool is_transparent =
+        has_is_transparent<Hash>::value && has_is_transparent<KeyEqual>::value;
+
+    using key_type = Key;
+    using mapped_type = T;
+    using value_type = typename std::conditional<
+        is_set, Key,
+        robin_hood::pair<typename std::conditional<is_flat, Key, Key const>::type, T>>::type;
+    using size_type = size_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using Self = Table<IsFlat, MaxLoadFactor100, key_type, mapped_type, hasher, key_equal>;
+
+private:
+    static_assert(MaxLoadFactor100 > 10 && MaxLoadFactor100 < 100,
+                  "MaxLoadFactor100 needs to be >10 && < 100");
+
+    using WHash = WrapHash<Hash>;
+    using WKeyEqual = WrapKeyEqual<KeyEqual>;
+
+    // configuration defaults
+
+    // make sure we have 8 elements, needed to quickly rehash mInfo
+    static constexpr size_t InitialNumElements = sizeof(uint64_t);
+    static constexpr uint32_t InitialInfoNumBits = 5;
+    static constexpr uint8_t InitialInfoInc = 1U << InitialInfoNumBits;
+    static constexpr size_t InfoMask = InitialInfoInc - 1U;
+    static constexpr uint8_t InitialInfoHashShift = 0;
+    using DataPool = detail::NodeAllocator<value_type, 4, 16384, IsFlat>;
+
+    // type needs to be wider than uint8_t.
+    using InfoType = uint32_t;
+
+    // DataNode ////////////////////////////////////////////////////////
+
+    // Primary template for the data node. We have special implementations for small and big
+    // objects. For large objects it is assumed that swap() is fairly slow, so we allocate these
+    // on the heap so swap merely swaps a pointer.
+    template <typename M, bool>
+    class DataNode {};
+
+    // Small: just allocate on the stack.
+    template <typename M>
+    class DataNode<M, true> final {
+    public:
+        template <typename... Args>
+        explicit DataNode(M& ROBIN_HOOD_UNUSED(map) /*unused*/, Args&&... args) noexcept(
+            noexcept(value_type(std::forward<Args>(args)...)))
+            : mData(std::forward<Args>(args)...) {}
+
+        DataNode(M& ROBIN_HOOD_UNUSED(map) /*unused*/, DataNode<M, true>&& n) noexcept(
+            std::is_nothrow_move_constructible<value_type>::value)
+            : mData(std::move(n.mData)) {}
+
+        // doesn't do anything
+        void destroy(M& ROBIN_HOOD_UNUSED(map) /*unused*/) noexcept {}
+        void destroyDoNotDeallocate() noexcept {}
+
+        value_type const* operator->() const noexcept {
+            return &mData;
+        }
+        value_type* operator->() noexcept {
+            return &mData;
+        }
+
+        const value_type& operator*() const noexcept {
+            return mData;
+        }
+
+        value_type& operator*() noexcept {
+            return mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type&>::type getFirst() noexcept {
+            return mData.first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT&>::type getFirst() noexcept {
+            return mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type const&>::type
+            getFirst() const noexcept {
+            return mData.first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT const&>::type getFirst() const noexcept {
+            return mData;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, MT&>::type getSecond() noexcept {
+            return mData.second;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, MT const&>::type getSecond() const noexcept {
+            return mData.second;
+        }
+
+        void swap(DataNode<M, true>& o) noexcept(
+            noexcept(std::declval<value_type>().swap(std::declval<value_type>()))) {
+            mData.swap(o.mData);
+        }
+
+    private:
+        value_type mData;
+    };
+
+    // big object: allocate on heap.
+    template <typename M>
+    class DataNode<M, false> {
+    public:
+        template <typename... Args>
+        explicit DataNode(M& map, Args&&... args)
+            : mData(map.allocate()) {
+            ::new (static_cast<void*>(mData)) value_type(std::forward<Args>(args)...);
+        }
+
+        DataNode(M& ROBIN_HOOD_UNUSED(map) /*unused*/, DataNode<M, false>&& n) noexcept
+            : mData(std::move(n.mData)) {}
+
+        void destroy(M& map) noexcept {
+            // don't deallocate, just put it into list of datapool.
+            mData->~value_type();
+            map.deallocate(mData);
+        }
+
+        void destroyDoNotDeallocate() noexcept {
+            mData->~value_type();
+        }
+
+        value_type const* operator->() const noexcept {
+            return mData;
+        }
+
+        value_type* operator->() noexcept {
+            return mData;
+        }
+
+        const value_type& operator*() const {
+            return *mData;
+        }
+
+        value_type& operator*() {
+            return *mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type&>::type getFirst() noexcept {
+            return mData->first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT&>::type getFirst() noexcept {
+            return *mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type const&>::type
+            getFirst() const noexcept {
+            return mData->first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT const&>::type getFirst() const noexcept {
+            return *mData;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, MT&>::type getSecond() noexcept {
+            return mData->second;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, MT const&>::type getSecond() const noexcept {
+            return mData->second;
+        }
+
+        void swap(DataNode<M, false>& o) noexcept {
+            using std::swap;
+            swap(mData, o.mData);
+        }
+
+    private:
+        value_type* mData;
+    };
+
+    using Node = DataNode<Self, IsFlat>;
+
+    // helpers for insertKeyPrepareEmptySpot: extract first entry (only const required)
+    ROBIN_HOOD(NODISCARD) key_type const& getFirstConst(Node const& n) const noexcept {
+        return n.getFirst();
+    }
+
+    // in case we have void mapped_type, we are not using a pair, thus we just route k through.
+    // No need to disable this because it's just not used if not applicable.
+    ROBIN_HOOD(NODISCARD) key_type const& getFirstConst(key_type const& k) const noexcept {
+        return k;
+    }
+
+    // in case we have non-void mapped_type, we have a standard robin_hood::pair
+    template <typename Q = mapped_type>
+    ROBIN_HOOD(NODISCARD)
+    typename std::enable_if<!std::is_void<Q>::value, key_type const&>::type
+        getFirstConst(value_type const& vt) const noexcept {
+        return vt.first;
+    }
+
+    // Cloner //////////////////////////////////////////////////////////
+
+    template <typename M, bool UseMemcpy>
+    struct Cloner;
+
+    // fast path: Just copy data, without allocating anything.
+    template <typename M>
+    struct Cloner<M, true> {
+        void operator()(M const& source, M& target) const {
+            auto const* const src = reinterpret_cast<char const*>(source.mKeyVals);
+            auto* tgt = reinterpret_cast<char*>(target.mKeyVals);
+            auto const numElementsWithBuffer = target.calcNumElementsWithBuffer(target.mMask + 1);
+            std::copy(src, src + target.calcNumBytesTotal(numElementsWithBuffer), tgt);
+        }
+    };
+
+    template <typename M>
+    struct Cloner<M, false> {
+        void operator()(M const& s, M& t) const {
+            auto const numElementsWithBuffer = t.calcNumElementsWithBuffer(t.mMask + 1);
+            std::copy(s.mInfo, s.mInfo + t.calcNumBytesInfo(numElementsWithBuffer), t.mInfo);
+
+            for (size_t i = 0; i < numElementsWithBuffer; ++i) {
+                if (t.mInfo[i]) {
+                    ::new (static_cast<void*>(t.mKeyVals + i)) Node(t, *s.mKeyVals[i]);
+                }
+            }
+        }
+    };
+
+    // Destroyer ///////////////////////////////////////////////////////
+
+    template <typename M, bool IsFlatAndTrivial>
+    struct Destroyer {};
+
+    template <typename M>
+    struct Destroyer<M, true> {
+        void nodes(M& m) const noexcept {
+            m.mNumElements = 0;
+        }
+
+        void nodesDoNotDeallocate(M& m) const noexcept {
+            m.mNumElements = 0;
+        }
+    };
+
+    template <typename M>
+    struct Destroyer<M, false> {
+        void nodes(M& m) const noexcept {
+            m.mNumElements = 0;
+            // clear also resets mInfo to 0, that's sometimes not necessary.
+            auto const numElementsWithBuffer = m.calcNumElementsWithBuffer(m.mMask + 1);
+
+            for (size_t idx = 0; idx < numElementsWithBuffer; ++idx) {
+                if (0 != m.mInfo[idx]) {
+                    Node& n = m.mKeyVals[idx];
+                    n.destroy(m);
+                    n.~Node();
+                }
+            }
+        }
+
+        void nodesDoNotDeallocate(M& m) const noexcept {
+            m.mNumElements = 0;
+            // clear also resets mInfo to 0, that's sometimes not necessary.
+            auto const numElementsWithBuffer = m.calcNumElementsWithBuffer(m.mMask + 1);
+            for (size_t idx = 0; idx < numElementsWithBuffer; ++idx) {
+                if (0 != m.mInfo[idx]) {
+                    Node& n = m.mKeyVals[idx];
+                    n.destroyDoNotDeallocate();
+                    n.~Node();
+                }
+            }
+        }
+    };
+
+    // Iter ////////////////////////////////////////////////////////////
+
+    struct fast_forward_tag {};
+
+    // generic iterator for both const_iterator and iterator.
+    template <bool IsConst>
+    // NOLINTNEXTLINE(hicpp-special-member-functions,cppcoreguidelines-special-member-functions)
+    class Iter {
+    private:
+        using NodePtr = typename std::conditional<IsConst, Node const*, Node*>::type;
+
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = typename Self::value_type;
+        using reference = typename std::conditional<IsConst, value_type const&, value_type&>::type;
+        using pointer = typename std::conditional<IsConst, value_type const*, value_type*>::type;
+        using iterator_category = std::forward_iterator_tag;
+
+        // default constructed iterator can be compared to itself, but WON'T return true when
+        // compared to end().
+        Iter() = default;
+
+        // Rule of zero: nothing specified. The conversion constructor is only enabled for
+        // iterator to const_iterator, so it doesn't accidentally work as a copy ctor.
+
+        // Conversion constructor from iterator to const_iterator.
+        template <bool OtherIsConst,
+                  typename = typename std::enable_if<IsConst && !OtherIsConst>::type>
+        // NOLINTNEXTLINE(hicpp-explicit-conversions)
+        Iter(Iter<OtherIsConst> const& other) noexcept
+            : mKeyVals(other.mKeyVals)
+            , mInfo(other.mInfo) {}
+
+        Iter(NodePtr valPtr, uint8_t const* infoPtr) noexcept
+            : mKeyVals(valPtr)
+            , mInfo(infoPtr) {}
+
+        Iter(NodePtr valPtr, uint8_t const* infoPtr,
+             fast_forward_tag ROBIN_HOOD_UNUSED(tag) /*unused*/) noexcept
+            : mKeyVals(valPtr)
+            , mInfo(infoPtr) {
+            fastForward();
+        }
+
+        template <bool OtherIsConst,
+                  typename = typename std::enable_if<IsConst && !OtherIsConst>::type>
+        Iter& operator=(Iter<OtherIsConst> const& other) noexcept {
+            mKeyVals = other.mKeyVals;
+            mInfo = other.mInfo;
+            return *this;
+        }
+
+        // prefix increment. Undefined behavior if we are at end()!
+        Iter& operator++() noexcept {
+            mInfo++;
+            mKeyVals++;
+            fastForward();
+            return *this;
+        }
+
+        Iter operator++(int) noexcept {
+            Iter tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        reference operator*() const {
+            return **mKeyVals;
+        }
+
+        pointer operator->() const {
+            return &**mKeyVals;
+        }
+
+        template <bool O>
+        bool operator==(Iter<O> const& o) const noexcept {
+            return mKeyVals == o.mKeyVals;
+        }
+
+        template <bool O>
+        bool operator!=(Iter<O> const& o) const noexcept {
+            return mKeyVals != o.mKeyVals;
+        }
+
+    private:
+        // fast forward to the next non-free info byte
+        // I've tried a few variants that don't depend on intrinsics, but unfortunately they are
+        // quite a bit slower than this one. So I've reverted that change again. See map_benchmark.
+        void fastForward() noexcept {
+            size_t n = 0;
+            while (0U == (n = detail::unaligned_load<size_t>(mInfo))) {
+                mInfo += sizeof(size_t);
+                mKeyVals += sizeof(size_t);
+            }
+#if defined(ROBIN_HOOD_DISABLE_INTRINSICS)
+            // we know for certain that within the next 8 bytes we'll find a non-zero one.
+            if (ROBIN_HOOD_UNLIKELY(0U == detail::unaligned_load<uint32_t>(mInfo))) {
+                mInfo += 4;
+                mKeyVals += 4;
+            }
+            if (ROBIN_HOOD_UNLIKELY(0U == detail::unaligned_load<uint16_t>(mInfo))) {
+                mInfo += 2;
+                mKeyVals += 2;
+            }
+            if (ROBIN_HOOD_UNLIKELY(0U == *mInfo)) {
+                mInfo += 1;
+                mKeyVals += 1;
+            }
+#else
+#    if ROBIN_HOOD(LITTLE_ENDIAN)
+            auto inc = ROBIN_HOOD_COUNT_TRAILING_ZEROES(n) / 8;
+#    else
+            auto inc = ROBIN_HOOD_COUNT_LEADING_ZEROES(n) / 8;
+#    endif
+            mInfo += inc;
+            mKeyVals += inc;
+#endif
+        }
+
+        friend class Table<IsFlat, MaxLoadFactor100, key_type, mapped_type, hasher, key_equal>;
+        NodePtr mKeyVals{nullptr};
+        uint8_t const* mInfo{nullptr};
+    };
+
+    ////////////////////////////////////////////////////////////////////
+
+    // highly performance relevant code.
+    // Lower bits are used for indexing into the array (2^n size)
+    // The upper 1-5 bits need to be a reasonable good hash, to save comparisons.
+    template <typename HashKey>
+    void keyToIdx(HashKey&& key, size_t* idx, InfoType* info) const {
+        // In addition to whatever hash is used, add another mul & shift so we get better hashing.
+        // This serves as a bad hash prevention, if the given data is
+        // badly mixed.
+        auto h = static_cast<uint64_t>(WHash::operator()(key));
+
+        h *= mHashMultiplier;
+        h ^= h >> 33U;
+
+        // the lower InitialInfoNumBits are reserved for info.
+        *info = mInfoInc + static_cast<InfoType>((h & InfoMask) >> mInfoHashShift);
+        *idx = (static_cast<size_t>(h) >> InitialInfoNumBits) & mMask;
+    }
+
+    // forwards the index by one, wrapping around at the end
+    void next(InfoType* info, size_t* idx) const noexcept {
+        *idx = *idx + 1;
+        *info += mInfoInc;
+    }
+
+    void nextWhileLess(InfoType* info, size_t* idx) const noexcept {
+        // unrolling this by hand did not bring any speedups.
+        while (*info < mInfo[*idx]) {
+            next(info, idx);
+        }
+    }
+
+    // Shift everything up by one element. Tries to move stuff around.
+    void
+    shiftUp(size_t startIdx,
+            size_t const insertion_idx) noexcept(std::is_nothrow_move_assignable<Node>::value) {
+        auto idx = startIdx;
+        ::new (static_cast<void*>(mKeyVals + idx)) Node(std::move(mKeyVals[idx - 1]));
+        while (--idx != insertion_idx) {
+            mKeyVals[idx] = std::move(mKeyVals[idx - 1]);
+        }
+
+        idx = startIdx;
+        while (idx != insertion_idx) {
+            ROBIN_HOOD_COUNT(shiftUp)
+            mInfo[idx] = static_cast<uint8_t>(mInfo[idx - 1] + mInfoInc);
+            if (ROBIN_HOOD_UNLIKELY(mInfo[idx] + mInfoInc > 0xFF)) {
+                mMaxNumElementsAllowed = 0;
+            }
+            --idx;
+        }
+    }
+
+    void shiftDown(size_t idx) noexcept(std::is_nothrow_move_assignable<Node>::value) {
+        // until we find one that is either empty or has zero offset.
+        // TODO(martinus) we don't need to move everything, just the last one for the same
+        // bucket.
+        mKeyVals[idx].destroy(*this);
+
+        // until we find one that is either empty or has zero offset.
+        while (mInfo[idx + 1] >= 2 * mInfoInc) {
+            ROBIN_HOOD_COUNT(shiftDown)
+            mInfo[idx] = static_cast<uint8_t>(mInfo[idx + 1] - mInfoInc);
+            mKeyVals[idx] = std::move(mKeyVals[idx + 1]);
+            ++idx;
+        }
+
+        mInfo[idx] = 0;
+        // don't destroy, we've moved it
+        // mKeyVals[idx].destroy(*this);
+        mKeyVals[idx].~Node();
+    }
+
+    // copy of find(), except that it returns iterator instead of const_iterator.
+    template <typename Other>
+    ROBIN_HOOD(NODISCARD)
+    size_t findIdx(Other const& key) const {
+        size_t idx{};
+        InfoType info{};
+        keyToIdx(key, &idx, &info);
+
+        do {
+            // unrolling this twice gives a bit of a speedup. More unrolling did not help.
+            if (info == mInfo[idx] &&
+                ROBIN_HOOD_LIKELY(WKeyEqual::operator()(key, mKeyVals[idx].getFirst()))) {
+                return idx;
+            }
+            next(&info, &idx);
+            if (info == mInfo[idx] &&
+                ROBIN_HOOD_LIKELY(WKeyEqual::operator()(key, mKeyVals[idx].getFirst()))) {
+                return idx;
+            }
+            next(&info, &idx);
+        } while (info <= mInfo[idx]);
+
+        // nothing found!
+        return mMask == 0 ? 0
+                          : static_cast<size_t>(std::distance(
+                                mKeyVals, reinterpret_cast_no_cast_align_warning<Node*>(mInfo)));
+    }
+
+    void cloneData(const Table& o) {
+        Cloner<Table, IsFlat && ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(Node)>()(o, *this);
+    }
+
+    // inserts a keyval that is guaranteed to be new, e.g. when the hashmap is resized.
+    // @return True on success, false if something went wrong
+    void insert_move(Node&& keyval) {
+        // we don't retry, fail if overflowing
+        // don't need to check max num elements
+        if (0 == mMaxNumElementsAllowed && !try_increase_info()) {
+            throwOverflowError();
+        }
+
+        size_t idx{};
+        InfoType info{};
+        keyToIdx(keyval.getFirst(), &idx, &info);
+
+        // skip forward. Use <= because we are certain that the element is not there.
+        while (info <= mInfo[idx]) {
+            idx = idx + 1;
+            info += mInfoInc;
+        }
+
+        // key not found, so we are now exactly where we want to insert it.
+        auto const insertion_idx = idx;
+        auto const insertion_info = static_cast<uint8_t>(info);
+        if (ROBIN_HOOD_UNLIKELY(insertion_info + mInfoInc > 0xFF)) {
+            mMaxNumElementsAllowed = 0;
+        }
+
+        // find an empty spot
+        while (0 != mInfo[idx]) {
+            next(&info, &idx);
+        }
+
+        auto& l = mKeyVals[insertion_idx];
+        if (idx == insertion_idx) {
+            ::new (static_cast<void*>(&l)) Node(std::move(keyval));
+        } else {
+            shiftUp(idx, insertion_idx);
+            l = std::move(keyval);
+        }
+
+        // put at empty spot
+        mInfo[insertion_idx] = insertion_info;
+
+        ++mNumElements;
+    }
+
+public:
+    using iterator = Iter<false>;
+    using const_iterator = Iter<true>;
+
+    Table() noexcept(noexcept(Hash()) && noexcept(KeyEqual()))
+        : WHash()
+        , WKeyEqual() {
+        ROBIN_HOOD_TRACE(this)
+    }
+
+    // Creates an empty hash map. Nothing is allocated yet, this happens at the first insert.
+    // This tremendously speeds up ctor & dtor of a map that never receives an element. The
+    // penalty is payed at the first insert, and not before. Lookup of this empty map works
+    // because everybody points to DummyInfoByte::b. parameter bucket_count is dictated by the
+    // standard, but we can ignore it.
+    explicit Table(
+        size_t ROBIN_HOOD_UNUSED(bucket_count) /*unused*/, const Hash& h = Hash{},
+        const KeyEqual& equal = KeyEqual{}) noexcept(noexcept(Hash(h)) && noexcept(KeyEqual(equal)))
+        : WHash(h)
+        , WKeyEqual(equal) {
+        ROBIN_HOOD_TRACE(this)
+    }
+
+    template <typename Iter>
+    Table(Iter first, Iter last, size_t ROBIN_HOOD_UNUSED(bucket_count) /*unused*/ = 0,
+          const Hash& h = Hash{}, const KeyEqual& equal = KeyEqual{})
+        : WHash(h)
+        , WKeyEqual(equal) {
+        ROBIN_HOOD_TRACE(this)
+        insert(first, last);
+    }
+
+    Table(std::initializer_list<value_type> initlist,
+          size_t ROBIN_HOOD_UNUSED(bucket_count) /*unused*/ = 0, const Hash& h = Hash{},
+          const KeyEqual& equal = KeyEqual{})
+        : WHash(h)
+        , WKeyEqual(equal) {
+        ROBIN_HOOD_TRACE(this)
+        insert(initlist.begin(), initlist.end());
+    }
+
+    Table(Table&& o) noexcept
+        : WHash(std::move(static_cast<WHash&>(o)))
+        , WKeyEqual(std::move(static_cast<WKeyEqual&>(o)))
+        , DataPool(std::move(static_cast<DataPool&>(o))) {
+        ROBIN_HOOD_TRACE(this)
+        if (o.mMask) {
+            mHashMultiplier = std::move(o.mHashMultiplier);
+            mKeyVals = std::move(o.mKeyVals);
+            mInfo = std::move(o.mInfo);
+            mNumElements = std::move(o.mNumElements);
+            mMask = std::move(o.mMask);
+            mMaxNumElementsAllowed = std::move(o.mMaxNumElementsAllowed);
+            mInfoInc = std::move(o.mInfoInc);
+            mInfoHashShift = std::move(o.mInfoHashShift);
+            // set other's mask to 0 so its destructor won't do anything
+            o.init();
+        }
+    }
+
+    Table& operator=(Table&& o) noexcept {
+        ROBIN_HOOD_TRACE(this)
+        if (&o != this) {
+            if (o.mMask) {
+                // only move stuff if the other map actually has some data
+                destroy();
+                mHashMultiplier = std::move(o.mHashMultiplier);
+                mKeyVals = std::move(o.mKeyVals);
+                mInfo = std::move(o.mInfo);
+                mNumElements = std::move(o.mNumElements);
+                mMask = std::move(o.mMask);
+                mMaxNumElementsAllowed = std::move(o.mMaxNumElementsAllowed);
+                mInfoInc = std::move(o.mInfoInc);
+                mInfoHashShift = std::move(o.mInfoHashShift);
+                WHash::operator=(std::move(static_cast<WHash&>(o)));
+                WKeyEqual::operator=(std::move(static_cast<WKeyEqual&>(o)));
+                DataPool::operator=(std::move(static_cast<DataPool&>(o)));
+
+                o.init();
+
+            } else {
+                // nothing in the other map => just clear us.
+                clear();
+            }
+        }
+        return *this;
+    }
+
+    Table(const Table& o)
+        : WHash(static_cast<const WHash&>(o))
+        , WKeyEqual(static_cast<const WKeyEqual&>(o))
+        , DataPool(static_cast<const DataPool&>(o)) {
+        ROBIN_HOOD_TRACE(this)
+        if (!o.empty()) {
+            // not empty: create an exact copy. it is also possible to just iterate through all
+            // elements and insert them, but copying is probably faster.
+
+            auto const numElementsWithBuffer = calcNumElementsWithBuffer(o.mMask + 1);
+            auto const numBytesTotal = calcNumBytesTotal(numElementsWithBuffer);
+
+            ROBIN_HOOD_LOG("std::malloc " << numBytesTotal << " = calcNumBytesTotal("
+                                          << numElementsWithBuffer << ")")
+            mHashMultiplier = o.mHashMultiplier;
+            mKeyVals = static_cast<Node*>(
+                detail::assertNotNull<std::bad_alloc>(std::malloc(numBytesTotal)));
+            // no need for calloc because clonData does memcpy
+            mInfo = reinterpret_cast<uint8_t*>(mKeyVals + numElementsWithBuffer);
+            mNumElements = o.mNumElements;
+            mMask = o.mMask;
+            mMaxNumElementsAllowed = o.mMaxNumElementsAllowed;
+            mInfoInc = o.mInfoInc;
+            mInfoHashShift = o.mInfoHashShift;
+            cloneData(o);
+        }
+    }
+
+    // Creates a copy of the given map. Copy constructor of each entry is used.
+    // Not sure why clang-tidy thinks this doesn't handle self assignment, it does
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
+    Table& operator=(Table const& o) {
+        ROBIN_HOOD_TRACE(this)
+        if (&o == this) {
+            // prevent assigning of itself
+            return *this;
+        }
+
+        // we keep using the old allocator and not assign the new one, because we want to keep
+        // the memory available. when it is the same size.
+        if (o.empty()) {
+            if (0 == mMask) {
+                // nothing to do, we are empty too
+                return *this;
+            }
+
+            // not empty: destroy what we have there
+            // clear also resets mInfo to 0, that's sometimes not necessary.
+            destroy();
+            init();
+            WHash::operator=(static_cast<const WHash&>(o));
+            WKeyEqual::operator=(static_cast<const WKeyEqual&>(o));
+            DataPool::operator=(static_cast<DataPool const&>(o));
+
+            return *this;
+        }
+
+        // clean up old stuff
+        Destroyer<Self, IsFlat && std::is_trivially_destructible<Node>::value>{}.nodes(*this);
+
+        if (mMask != o.mMask) {
+            // no luck: we don't have the same array size allocated, so we need to realloc.
+            if (0 != mMask) {
+                // only deallocate if we actually have data!
+                ROBIN_HOOD_LOG("std::free")
+                std::free(mKeyVals);
+            }
+
+            auto const numElementsWithBuffer = calcNumElementsWithBuffer(o.mMask + 1);
+            auto const numBytesTotal = calcNumBytesTotal(numElementsWithBuffer);
+            ROBIN_HOOD_LOG("std::malloc " << numBytesTotal << " = calcNumBytesTotal("
+                                          << numElementsWithBuffer << ")")
+            mKeyVals = static_cast<Node*>(
+                detail::assertNotNull<std::bad_alloc>(std::malloc(numBytesTotal)));
+
+            // no need for calloc here because cloneData performs a memcpy.
+            mInfo = reinterpret_cast<uint8_t*>(mKeyVals + numElementsWithBuffer);
+            // sentinel is set in cloneData
+        }
+        WHash::operator=(static_cast<const WHash&>(o));
+        WKeyEqual::operator=(static_cast<const WKeyEqual&>(o));
+        DataPool::operator=(static_cast<DataPool const&>(o));
+        mHashMultiplier = o.mHashMultiplier;
+        mNumElements = o.mNumElements;
+        mMask = o.mMask;
+        mMaxNumElementsAllowed = o.mMaxNumElementsAllowed;
+        mInfoInc = o.mInfoInc;
+        mInfoHashShift = o.mInfoHashShift;
+        cloneData(o);
+
+        return *this;
+    }
+
+    // Swaps everything between the two maps.
+    void swap(Table& o) {
+        ROBIN_HOOD_TRACE(this)
+        using std::swap;
+        swap(o, *this);
+    }
+
+    // Clears all data, without resizing.
+    void clear() {
+        ROBIN_HOOD_TRACE(this)
+        if (empty()) {
+            // don't do anything! also important because we don't want to write to
+            // DummyInfoByte::b, even though we would just write 0 to it.
+            return;
+        }
+
+        Destroyer<Self, IsFlat && std::is_trivially_destructible<Node>::value>{}.nodes(*this);
+
+        auto const numElementsWithBuffer = calcNumElementsWithBuffer(mMask + 1);
+        // clear everything, then set the sentinel again
+        uint8_t const z = 0;
+        std::fill(mInfo, mInfo + calcNumBytesInfo(numElementsWithBuffer), z);
+        mInfo[numElementsWithBuffer] = 1;
+
+        mInfoInc = InitialInfoInc;
+        mInfoHashShift = InitialInfoHashShift;
+    }
+
+    // Destroys the map and all it's contents.
+    ~Table() {
+        ROBIN_HOOD_TRACE(this)
+        destroy();
+    }
+
+    // Checks if both tables contain the same entries. Order is irrelevant.
+    bool operator==(const Table& other) const {
+        ROBIN_HOOD_TRACE(this)
+        if (other.size() != size()) {
+            return false;
+        }
+        for (auto const& otherEntry : other) {
+            if (!has(otherEntry)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool operator!=(const Table& other) const {
+        ROBIN_HOOD_TRACE(this)
+        return !operator==(other);
+    }
+
+    template <typename Q = mapped_type>
+    typename std::enable_if<!std::is_void<Q>::value, Q&>::type operator[](const key_type& key) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first]))
+                Node(*this, std::piecewise_construct, std::forward_as_tuple(key),
+                     std::forward_as_tuple());
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = Node(*this, std::piecewise_construct,
+                                               std::forward_as_tuple(key), std::forward_as_tuple());
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+        }
+
+        return mKeyVals[idxAndState.first].getSecond();
+    }
+
+    template <typename Q = mapped_type>
+    typename std::enable_if<!std::is_void<Q>::value, Q&>::type operator[](key_type&& key) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first]))
+                Node(*this, std::piecewise_construct, std::forward_as_tuple(std::move(key)),
+                     std::forward_as_tuple());
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] =
+                Node(*this, std::piecewise_construct, std::forward_as_tuple(std::move(key)),
+                     std::forward_as_tuple());
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+        }
+
+        return mKeyVals[idxAndState.first].getSecond();
+    }
+
+    template <typename Iter>
+    void insert(Iter first, Iter last) {
+        for (; first != last; ++first) {
+            // value_type ctor needed because this might be called with std::pair's
+            insert(value_type(*first));
+        }
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        for (auto&& vt : ilist) {
+            insert(std::move(vt));
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        ROBIN_HOOD_TRACE(this)
+        Node n{*this, std::forward<Args>(args)...};
+        auto idxAndState = insertKeyPrepareEmptySpot(getFirstConst(n));
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            n.destroy(*this);
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first])) Node(*this, std::move(n));
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = std::move(n);
+            break;
+
+        case InsertionState::overflow_error:
+            n.destroy(*this);
+            throwOverflowError();
+            break;
+        }
+
+        return std::make_pair(iterator(mKeyVals + idxAndState.first, mInfo + idxAndState.first),
+                              InsertionState::key_found != idxAndState.second);
+    }
+
+    template <typename... Args>
+    iterator emplace_hint(const_iterator position, Args&&... args) {
+        (void)position;
+        return emplace(std::forward<Args>(args)...).first;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const key_type& key, Args&&... args) {
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(key_type&& key, Args&&... args) {
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, const key_type& key,
+                                          Args&&... args) {
+        (void)hint;
+        return try_emplace_impl(key, std::forward<Args>(args)...).first;
+    }
+
+    template <typename... Args>
+    iterator try_emplace(const_iterator hint, key_type&& key, Args&&... args) {
+        (void)hint;
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...).first;
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const key_type& key, Mapped&& obj) {
+        return insertOrAssignImpl(key, std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(key_type&& key, Mapped&& obj) {
+        return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    iterator insert_or_assign(const_iterator hint, const key_type& key,
+                                               Mapped&& obj) {
+        (void)hint;
+        return insertOrAssignImpl(key, std::forward<Mapped>(obj)).first;
+    }
+
+    template <typename Mapped>
+    iterator insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj) {
+        (void)hint;
+        return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj)).first;
+    }
+
+    std::pair<iterator, bool> insert(const value_type& keyval) {
+        ROBIN_HOOD_TRACE(this)
+        return emplace(keyval);
+    }
+
+    iterator insert(const_iterator hint, const value_type& keyval) {
+        (void)hint;
+        return emplace(keyval).first;
+    }
+
+    std::pair<iterator, bool> insert(value_type&& keyval) {
+        return emplace(std::move(keyval));
+    }
+
+    iterator insert(const_iterator hint, value_type&& keyval) {
+        (void)hint;
+        return emplace(std::move(keyval)).first;
+    }
+
+    // Returns 1 if key is found, 0 otherwise.
+    size_t count(const key_type& key) const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv != reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<Self_::is_transparent, size_t>::type count(const OtherKey& key) const {
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv != reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    bool contains(const key_type& key) const { // NOLINT(modernize-use-nodiscard)
+        return 1U == count(key);
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<Self_::is_transparent, bool>::type contains(const OtherKey& key) const {
+        return 1U == count(key);
+    }
+
+    // Returns a reference to the value found for key.
+    // Throws std::out_of_range if element cannot be found
+    template <typename Q = mapped_type>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<!std::is_void<Q>::value, Q&>::type at(key_type const& key) {
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv == reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            doThrow<std::out_of_range>("key not found");
+        }
+        return kv->getSecond();
+    }
+
+    // Returns a reference to the value found for key.
+    // Throws std::out_of_range if element cannot be found
+    template <typename Q = mapped_type>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<!std::is_void<Q>::value, Q const&>::type at(key_type const& key) const {
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv == reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            doThrow<std::out_of_range>("key not found");
+        }
+        return kv->getSecond();
+    }
+
+    const_iterator find(const key_type& key) const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey>
+    const_iterator find(const OtherKey& key, is_transparent_tag /*unused*/) const {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    typename std::enable_if<Self_::is_transparent, // NOLINT(modernize-use-nodiscard)
+                            const_iterator>::type  // NOLINT(modernize-use-nodiscard)
+    find(const OtherKey& key) const {              // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    iterator find(const key_type& key) {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey>
+    iterator find(const OtherKey& key, is_transparent_tag /*unused*/) {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    typename std::enable_if<Self_::is_transparent, iterator>::type find(const OtherKey& key) {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    iterator begin() {
+        ROBIN_HOOD_TRACE(this)
+        if (empty()) {
+            return end();
+        }
+        return iterator(mKeyVals, mInfo, fast_forward_tag{});
+    }
+    const_iterator begin() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return cbegin();
+    }
+    const_iterator cbegin() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        if (empty()) {
+            return cend();
+        }
+        return const_iterator(mKeyVals, mInfo, fast_forward_tag{});
+    }
+
+    iterator end() {
+        ROBIN_HOOD_TRACE(this)
+        // no need to supply valid info pointer: end() must not be dereferenced, and only node
+        // pointer is compared.
+        return iterator{reinterpret_cast_no_cast_align_warning<Node*>(mInfo), nullptr};
+    }
+    const_iterator end() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return cend();
+    }
+    const_iterator cend() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return const_iterator{reinterpret_cast_no_cast_align_warning<Node*>(mInfo), nullptr};
+    }
+
+    iterator erase(const_iterator pos) {
+        ROBIN_HOOD_TRACE(this)
+        // its safe to perform const cast here
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        return erase(iterator{const_cast<Node*>(pos.mKeyVals), const_cast<uint8_t*>(pos.mInfo)});
+    }
+
+    // Erases element at pos, returns iterator to the next element.
+    iterator erase(iterator pos) {
+        ROBIN_HOOD_TRACE(this)
+        // we assume that pos always points to a valid entry, and not end().
+        auto const idx = static_cast<size_t>(pos.mKeyVals - mKeyVals);
+
+        shiftDown(idx);
+        --mNumElements;
+
+        if (*pos.mInfo) {
+            // we've backward shifted, return this again
+            return pos;
+        }
+
+        // no backward shift, return next element
+        return ++pos;
+    }
+
+    size_t erase(const key_type& key) {
+        ROBIN_HOOD_TRACE(this)
+        size_t idx{};
+        InfoType info{};
+        keyToIdx(key, &idx, &info);
+
+        // check while info matches with the source idx
+        do {
+            if (info == mInfo[idx] && WKeyEqual::operator()(key, mKeyVals[idx].getFirst())) {
+                shiftDown(idx);
+                --mNumElements;
+                return 1;
+            }
+            next(&info, &idx);
+        } while (info <= mInfo[idx]);
+
+        // nothing found to delete
+        return 0;
+    }
+
+    // reserves space for the specified number of elements. Makes sure the old data fits.
+    // exactly the same as reserve(c).
+    void rehash(size_t c) {
+        // forces a reserve
+        reserve(c, true);
+    }
+
+    // reserves space for the specified number of elements. Makes sure the old data fits.
+    // Exactly the same as rehash(c). Use rehash(0) to shrink to fit.
+    void reserve(size_t c) {
+        // reserve, but don't force rehash
+        reserve(c, false);
+    }
+
+    // If possible reallocates the map to a smaller one. This frees the underlying table.
+    // Does not do anything if load_factor is too large for decreasing the table's size.
+    void compact() {
+        ROBIN_HOOD_TRACE(this)
+        auto newSize = InitialNumElements;
+        while (calcMaxNumElementsAllowed(newSize) < mNumElements && newSize != 0) {
+            newSize *= 2;
+        }
+        if (ROBIN_HOOD_UNLIKELY(newSize == 0)) {
+            throwOverflowError();
+        }
+
+        ROBIN_HOOD_LOG("newSize > mMask + 1: " << newSize << " > " << mMask << " + 1")
+
+        // only actually do anything when the new size is bigger than the old one. This prevents to
+        // continuously allocate for each reserve() call.
+        if (newSize < mMask + 1) {
+            rehashPowerOfTwo(newSize, true);
+        }
+    }
+
+    size_type size() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return mNumElements;
+    }
+
+    size_type max_size() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return static_cast<size_type>(-1);
+    }
+
+    ROBIN_HOOD(NODISCARD) bool empty() const noexcept {
+        ROBIN_HOOD_TRACE(this)
+        return 0 == mNumElements;
+    }
+
+    float max_load_factor() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return MaxLoadFactor100 / 100.0F;
+    }
+
+    // Average number of elements per bucket. Since we allow only 1 per bucket
+    float load_factor() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return static_cast<float>(size()) / static_cast<float>(mMask + 1);
+    }
+
+    ROBIN_HOOD(NODISCARD) size_t mask() const noexcept {
+        ROBIN_HOOD_TRACE(this)
+        return mMask;
+    }
+
+    ROBIN_HOOD(NODISCARD) size_t calcMaxNumElementsAllowed(size_t maxElements) const noexcept {
+        if (ROBIN_HOOD_LIKELY(maxElements <= (std::numeric_limits<size_t>::max)() / 100)) {
+            return maxElements * MaxLoadFactor100 / 100;
+        }
+
+        // we might be a bit inprecise, but since maxElements is quite large that doesn't matter
+        return (maxElements / 100) * MaxLoadFactor100;
+    }
+
+    ROBIN_HOOD(NODISCARD) size_t calcNumBytesInfo(size_t numElements) const noexcept {
+        // we add a uint64_t, which houses the sentinel (first byte) and padding so we can load
+        // 64bit types.
+        return numElements + sizeof(uint64_t);
+    }
+
+    ROBIN_HOOD(NODISCARD)
+    size_t calcNumElementsWithBuffer(size_t numElements) const noexcept {
+        auto maxNumElementsAllowed = calcMaxNumElementsAllowed(numElements);
+        return numElements + (std::min)(maxNumElementsAllowed, (static_cast<size_t>(0xFF)));
+    }
+
+    // calculation only allowed for 2^n values
+    ROBIN_HOOD(NODISCARD) size_t calcNumBytesTotal(size_t numElements) const {
+#if ROBIN_HOOD(BITNESS) == 64
+        return numElements * sizeof(Node) + calcNumBytesInfo(numElements);
+#else
+        // make sure we're doing 64bit operations, so we are at least safe against 32bit overflows.
+        auto const ne = static_cast<uint64_t>(numElements);
+        auto const s = static_cast<uint64_t>(sizeof(Node));
+        auto const infos = static_cast<uint64_t>(calcNumBytesInfo(numElements));
+
+        auto const total64 = ne * s + infos;
+        auto const total = static_cast<size_t>(total64);
+
+        if (ROBIN_HOOD_UNLIKELY(static_cast<uint64_t>(total) != total64)) {
+            throwOverflowError();
+        }
+        return total;
+#endif
+    }
+
+private:
+    template <typename Q = mapped_type>
+    ROBIN_HOOD(NODISCARD)
+    typename std::enable_if<!std::is_void<Q>::value, bool>::type has(const value_type& e) const {
+        ROBIN_HOOD_TRACE(this)
+        auto it = find(e.first);
+        return it != end() && it->second == e.second;
+    }
+
+    template <typename Q = mapped_type>
+    ROBIN_HOOD(NODISCARD)
+    typename std::enable_if<std::is_void<Q>::value, bool>::type has(const value_type& e) const {
+        ROBIN_HOOD_TRACE(this)
+        return find(e) != end();
+    }
+
+    void reserve(size_t c, bool forceRehash) {
+        ROBIN_HOOD_TRACE(this)
+        auto const minElementsAllowed = (std::max)(c, mNumElements);
+        auto newSize = InitialNumElements;
+        while (calcMaxNumElementsAllowed(newSize) < minElementsAllowed && newSize != 0) {
+            newSize *= 2;
+        }
+        if (ROBIN_HOOD_UNLIKELY(newSize == 0)) {
+            throwOverflowError();
+        }
+
+        ROBIN_HOOD_LOG("newSize > mMask + 1: " << newSize << " > " << mMask << " + 1")
+
+        // only actually do anything when the new size is bigger than the old one. This prevents to
+        // continuously allocate for each reserve() call.
+        if (forceRehash || newSize > mMask + 1) {
+            rehashPowerOfTwo(newSize, false);
+        }
+    }
+
+    // reserves space for at least the specified number of elements.
+    // only works if numBuckets if power of two
+    // True on success, false otherwise
+    void rehashPowerOfTwo(size_t numBuckets, bool forceFree) {
+        ROBIN_HOOD_TRACE(this)
+
+        Node* const oldKeyVals = mKeyVals;
+        uint8_t const* const oldInfo = mInfo;
+
+        const size_t oldMaxElementsWithBuffer = calcNumElementsWithBuffer(mMask + 1);
+
+        // resize operation: move stuff
+        initData(numBuckets);
+        if (oldMaxElementsWithBuffer > 1) {
+            for (size_t i = 0; i < oldMaxElementsWithBuffer; ++i) {
+                if (oldInfo[i] != 0) {
+                    // might throw an exception, which is really bad since we are in the middle of
+                    // moving stuff.
+                    insert_move(std::move(oldKeyVals[i]));
+                    // destroy the node but DON'T destroy the data.
+                    oldKeyVals[i].~Node();
+                }
+            }
+
+            // this check is not necessary as it's guarded by the previous if, but it helps
+            // silence g++'s overeager "attempt to free a non-heap object 'map'
+            // [-Werror=free-nonheap-object]" warning.
+            if (oldKeyVals != reinterpret_cast_no_cast_align_warning<Node*>(&mMask)) {
+                // don't destroy old data: put it into the pool instead
+                if (forceFree) {
+                    std::free(oldKeyVals);
+                } else {
+                    DataPool::addOrFree(oldKeyVals, calcNumBytesTotal(oldMaxElementsWithBuffer));
+                }
+            }
+        }
+    }
+
+    ROBIN_HOOD(NOINLINE) void throwOverflowError() const {
+#if ROBIN_HOOD(HAS_EXCEPTIONS)
+        throw std::overflow_error("robin_hood::map overflow");
+#else
+        abort();
+#endif
+    }
+
+    template <typename OtherKey, typename... Args>
+    std::pair<iterator, bool> try_emplace_impl(OtherKey&& key, Args&&... args) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first])) Node(
+                *this, std::piecewise_construct, std::forward_as_tuple(std::forward<OtherKey>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...));
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = Node(*this, std::piecewise_construct,
+                                               std::forward_as_tuple(std::forward<OtherKey>(key)),
+                                               std::forward_as_tuple(std::forward<Args>(args)...));
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+            break;
+        }
+
+        return std::make_pair(iterator(mKeyVals + idxAndState.first, mInfo + idxAndState.first),
+                              InsertionState::key_found != idxAndState.second);
+    }
+
+    template <typename OtherKey, typename Mapped>
+    std::pair<iterator, bool> insertOrAssignImpl(OtherKey&& key, Mapped&& obj) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            mKeyVals[idxAndState.first].getSecond() = std::forward<Mapped>(obj);
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first])) Node(
+                *this, std::piecewise_construct, std::forward_as_tuple(std::forward<OtherKey>(key)),
+                std::forward_as_tuple(std::forward<Mapped>(obj)));
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = Node(*this, std::piecewise_construct,
+                                               std::forward_as_tuple(std::forward<OtherKey>(key)),
+                                               std::forward_as_tuple(std::forward<Mapped>(obj)));
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+            break;
+        }
+
+        return std::make_pair(iterator(mKeyVals + idxAndState.first, mInfo + idxAndState.first),
+                              InsertionState::key_found != idxAndState.second);
+    }
+
+    void initData(size_t max_elements) {
+        mNumElements = 0;
+        mMask = max_elements - 1;
+        mMaxNumElementsAllowed = calcMaxNumElementsAllowed(max_elements);
+
+        auto const numElementsWithBuffer = calcNumElementsWithBuffer(max_elements);
+
+        // calloc also zeroes everything
+        auto const numBytesTotal = calcNumBytesTotal(numElementsWithBuffer);
+        ROBIN_HOOD_LOG("std::calloc " << numBytesTotal << " = calcNumBytesTotal("
+                                      << numElementsWithBuffer << ")")
+        mKeyVals = reinterpret_cast<Node*>(
+            detail::assertNotNull<std::bad_alloc>(std::calloc(1, numBytesTotal)));
+        mInfo = reinterpret_cast<uint8_t*>(mKeyVals + numElementsWithBuffer);
+
+        // set sentinel
+        mInfo[numElementsWithBuffer] = 1;
+
+        mInfoInc = InitialInfoInc;
+        mInfoHashShift = InitialInfoHashShift;
+    }
+
+    enum class InsertionState { overflow_error, key_found, new_node, overwrite_node };
+
+    // Finds key, and if not already present prepares a spot where to pot the key & value.
+    // This potentially shifts nodes out of the way, updates mInfo and number of inserted
+    // elements, so the only operation left to do is create/assign a new node at that spot.
+    template <typename OtherKey>
+    std::pair<size_t, InsertionState> insertKeyPrepareEmptySpot(OtherKey&& key) {
+        for (int i = 0; i < 256; ++i) {
+            size_t idx{};
+            InfoType info{};
+            keyToIdx(key, &idx, &info);
+            nextWhileLess(&info, &idx);
+
+            // while we potentially have a match
+            while (info == mInfo[idx]) {
+                if (WKeyEqual::operator()(key, mKeyVals[idx].getFirst())) {
+                    // key already exists, do NOT insert.
+                    // see http://en.cppreference.com/w/cpp/container/unordered_map/insert
+                    return std::make_pair(idx, InsertionState::key_found);
+                }
+                next(&info, &idx);
+            }
+
+            // unlikely that this evaluates to true
+            if (ROBIN_HOOD_UNLIKELY(mNumElements >= mMaxNumElementsAllowed)) {
+                if (!increase_size()) {
+                    return std::make_pair(size_t(0), InsertionState::overflow_error);
+                }
+                continue;
+            }
+
+            // key not found, so we are now exactly where we want to insert it.
+            auto const insertion_idx = idx;
+            auto const insertion_info = info;
+            if (ROBIN_HOOD_UNLIKELY(insertion_info + mInfoInc > 0xFF)) {
+                mMaxNumElementsAllowed = 0;
+            }
+
+            // find an empty spot
+            while (0 != mInfo[idx]) {
+                next(&info, &idx);
+            }
+
+            if (idx != insertion_idx) {
+                shiftUp(idx, insertion_idx);
+            }
+            // put at empty spot
+            mInfo[insertion_idx] = static_cast<uint8_t>(insertion_info);
+            ++mNumElements;
+            return std::make_pair(insertion_idx, idx == insertion_idx
+                                                     ? InsertionState::new_node
+                                                     : InsertionState::overwrite_node);
+        }
+
+        // enough attempts failed, so finally give up.
+        return std::make_pair(size_t(0), InsertionState::overflow_error);
+    }
+
+    bool try_increase_info() {
+        ROBIN_HOOD_LOG("mInfoInc=" << mInfoInc << ", numElements=" << mNumElements
+                                   << ", maxNumElementsAllowed="
+                                   << calcMaxNumElementsAllowed(mMask + 1))
+        if (mInfoInc <= 2) {
+            // need to be > 2 so that shift works (otherwise undefined behavior!)
+            return false;
+        }
+        // we got space left, try to make info smaller
+        mInfoInc = static_cast<uint8_t>(mInfoInc >> 1U);
+
+        // remove one bit of the hash, leaving more space for the distance info.
+        // This is extremely fast because we can operate on 8 bytes at once.
+        ++mInfoHashShift;
+        auto const numElementsWithBuffer = calcNumElementsWithBuffer(mMask + 1);
+
+        for (size_t i = 0; i < numElementsWithBuffer; i += 8) {
+            auto val = unaligned_load<uint64_t>(mInfo + i);
+            val = (val >> 1U) & UINT64_C(0x7f7f7f7f7f7f7f7f);
+            std::memcpy(mInfo + i, &val, sizeof(val));
+        }
+        // update sentinel, which might have been cleared out!
+        mInfo[numElementsWithBuffer] = 1;
+
+        mMaxNumElementsAllowed = calcMaxNumElementsAllowed(mMask + 1);
+        return true;
+    }
+
+    // True if resize was possible, false otherwise
+    bool increase_size() {
+        // nothing allocated yet? just allocate InitialNumElements
+        if (0 == mMask) {
+            initData(InitialNumElements);
+            return true;
+        }
+
+        auto const maxNumElementsAllowed = calcMaxNumElementsAllowed(mMask + 1);
+        if (mNumElements < maxNumElementsAllowed && try_increase_info()) {
+            return true;
+        }
+
+        ROBIN_HOOD_LOG("mNumElements=" << mNumElements << ", maxNumElementsAllowed="
+                                       << maxNumElementsAllowed << ", load="
+                                       << (static_cast<double>(mNumElements) * 100.0 /
+                                           (static_cast<double>(mMask) + 1)))
+
+        if (mNumElements * 2 < calcMaxNumElementsAllowed(mMask + 1)) {
+            // we have to resize, even though there would still be plenty of space left!
+            // Try to rehash instead. Delete freed memory so we don't steadyily increase mem in case
+            // we have to rehash a few times
+            nextHashMultiplier();
+            rehashPowerOfTwo(mMask + 1, true);
+        } else {
+            // we've reached the capacity of the map, so the hash seems to work nice. Keep using it.
+            rehashPowerOfTwo((mMask + 1) * 2, false);
+        }
+        return true;
+    }
+
+    void nextHashMultiplier() {
+        // adding an *even* number, so that the multiplier will always stay odd. This is necessary
+        // so that the hash stays a mixing function (and thus doesn't have any information loss).
+        mHashMultiplier += UINT64_C(0xc4ceb9fe1a85ec54);
+    }
+
+    void destroy() {
+        if (0 == mMask) {
+            // don't deallocate!
+            return;
+        }
+
+        Destroyer<Self, IsFlat && std::is_trivially_destructible<Node>::value>{}
+            .nodesDoNotDeallocate(*this);
+
+        // This protection against not deleting mMask shouldn't be needed as it's sufficiently
+        // protected with the 0==mMask check, but I have this anyways because g++ 7 otherwise
+        // reports a compile error: attempt to free a non-heap object 'fm'
+        // [-Werror=free-nonheap-object]
+        if (mKeyVals != reinterpret_cast_no_cast_align_warning<Node*>(&mMask)) {
+            ROBIN_HOOD_LOG("std::free")
+            std::free(mKeyVals);
+        }
+    }
+
+    void init() noexcept {
+        mKeyVals = reinterpret_cast_no_cast_align_warning<Node*>(&mMask);
+        mInfo = reinterpret_cast<uint8_t*>(&mMask);
+        mNumElements = 0;
+        mMask = 0;
+        mMaxNumElementsAllowed = 0;
+        mInfoInc = InitialInfoInc;
+        mInfoHashShift = InitialInfoHashShift;
+    }
+
+    // members are sorted so no padding occurs
+    uint64_t mHashMultiplier = UINT64_C(0xc4ceb9fe1a85ec53);                // 8 byte  8
+    Node* mKeyVals = reinterpret_cast_no_cast_align_warning<Node*>(&mMask); // 8 byte 16
+    uint8_t* mInfo = reinterpret_cast<uint8_t*>(&mMask);                    // 8 byte 24
+    size_t mNumElements = 0;                                                // 8 byte 32
+    size_t mMask = 0;                                                       // 8 byte 40
+    size_t mMaxNumElementsAllowed = 0;                                      // 8 byte 48
+    InfoType mInfoInc = InitialInfoInc;                                     // 4 byte 52
+    InfoType mInfoHashShift = InitialInfoHashShift;                         // 4 byte 56
+                                                    // 16 byte 56 if NodeAllocator
+};
+
+} // namespace detail
+
+// map
+
+template <typename Key, typename T, typename Hash = hash<Key>,
+          typename KeyEqual = std::equal_to<Key>, size_t MaxLoadFactor100 = 80>
+using unordered_flat_map = detail::Table<true, MaxLoadFactor100, Key, T, Hash, KeyEqual>;
+
+template <typename Key, typename T, typename Hash = hash<Key>,
+          typename KeyEqual = std::equal_to<Key>, size_t MaxLoadFactor100 = 80>
+using unordered_node_map = detail::Table<false, MaxLoadFactor100, Key, T, Hash, KeyEqual>;
+
+template <typename Key, typename T, typename Hash = hash<Key>,
+          typename KeyEqual = std::equal_to<Key>, size_t MaxLoadFactor100 = 80>
+using unordered_map =
+    detail::Table<sizeof(robin_hood::pair<Key, T>) <= sizeof(size_t) * 6 &&
+                      std::is_nothrow_move_constructible<robin_hood::pair<Key, T>>::value &&
+                      std::is_nothrow_move_assignable<robin_hood::pair<Key, T>>::value,
+                  MaxLoadFactor100, Key, T, Hash, KeyEqual>;
+
+// set
+
+template <typename Key, typename Hash = hash<Key>, typename KeyEqual = std::equal_to<Key>,
+          size_t MaxLoadFactor100 = 80>
+using unordered_flat_set = detail::Table<true, MaxLoadFactor100, Key, void, Hash, KeyEqual>;
+
+template <typename Key, typename Hash = hash<Key>, typename KeyEqual = std::equal_to<Key>,
+          size_t MaxLoadFactor100 = 80>
+using unordered_node_set = detail::Table<false, MaxLoadFactor100, Key, void, Hash, KeyEqual>;
+
+template <typename Key, typename Hash = hash<Key>, typename KeyEqual = std::equal_to<Key>,
+          size_t MaxLoadFactor100 = 80>
+using unordered_set = detail::Table<sizeof(Key) <= sizeof(size_t) * 6 &&
+                                        std::is_nothrow_move_constructible<Key>::value &&
+                                        std::is_nothrow_move_assignable<Key>::value,
+                                    MaxLoadFactor100, Key, void, Hash, KeyEqual>;
+
+} // namespace robin_hood
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ package_dir = {k: os.path.join('.', k.replace(".", "/")) for k in packages}
 package_data = {
     project_var_name + ".algorithms": ["*.cpp", "*.hpp"],
     project_var_name + ".examples": ["*.cpp", "*.hpp", "*.h"],
+    project_var_name + ".fastdata": ["*.cpp", "*.hpp", "*.pyx"],
     project_var_name + ".io": ["*.cpp", "*.hpp"],
     project_var_name + ".numbers": ["*.cpp", "*.h", "*.pyx"],
     project_var_name + ".parallel": ["*.cpp", "*.hpp"],
@@ -130,6 +131,30 @@ def get_extensions():
         ],
         language='c++',
         define_macros=define_macros)
+
+    ext_fast_dict = Extension(
+        'cpyquickhelper.fastdata.fast_dict',
+        [os.path.join(root, 'cpyquickhelper/fastdata/fast_dict.cpp')],
+        extra_compile_args=extra_compile_args_numbers,
+        extra_link_args=extra_link_args,
+        include_dirs=[
+            # Path to pybind11 headers
+            get_pybind_include(),
+            get_pybind_include(user=True),
+            os.path.join(root, 'cpyquickhelper/fastdata')
+        ],
+        language='c++',
+        define_macros=define_macros)
+
+    pattern1 = "cpyquickhelper.fastdata.%s"
+    name = 'fast_dict_cpy'
+    ext_fast_dict_cpy = Extension(
+        pattern1 % name,
+        ['cpyquickhelper/fastdata/%s.pyx' % name],
+        include_dirs=[numpy.get_include()],
+        extra_compile_args=["-O3"],
+        define_macros=define_macros,
+        language="c++")
 
     ext_thread = Extension(
         'cpyquickhelper.parallel.threader',
@@ -273,7 +298,7 @@ def get_extensions():
 
     try:
         from Cython.Build import cythonize
-        ext_modules = cythonize([ext_blas],
+        ext_modules = cythonize([ext_blas, ext_fast_dict_cpy],
                                 compiler_directives=opts)
     except ImportError:
         # Cython is not installed.
@@ -284,6 +309,7 @@ def get_extensions():
     # setup
     if ext_modules is not None:
         ext_modules.extend([
+            ext_fast_dict,
             ext_edit_distance_c,
             ext_slowcode,
             ext_custom_container,

--- a/setup.py
+++ b/setup.py
@@ -292,10 +292,7 @@ def get_extensions():
 
     ext_fast_dict_c = Extension(
         'cpyquickhelper.fastdata.fast_dict_c',
-        [os.path.join(root, 'cpyquickhelper/fastdata/fast_dict_c.cpp'),
-         os.path.join(
-             root, 'cpyquickhelper/fastdata/fast_dict_c.cpp'),
-         os.path.join(root, 'cpyquickhelper/fastdata/fast_dict_c.cpp')],
+        [os.path.join(root, 'cpyquickhelper/fastdata/fast_dict_c.cpp')],
         extra_compile_args=extra_compile_args_numbers,
         extra_link_args=extra_link_args,
         include_dirs=[

--- a/setup.py
+++ b/setup.py
@@ -290,6 +290,23 @@ def get_extensions():
         language='c++',
         define_macros=define_macros)
 
+    ext_fast_dict_c = Extension(
+        'cpyquickhelper.fastdata.fast_dict_c',
+        [os.path.join(root, 'cpyquickhelper/fastdata/fast_dict_c.cpp'),
+         os.path.join(
+             root, 'cpyquickhelper/fastdata/fast_dict_c.cpp'),
+         os.path.join(root, 'cpyquickhelper/fastdata/fast_dict_c.cpp')],
+        extra_compile_args=extra_compile_args_numbers,
+        extra_link_args=extra_link_args,
+        include_dirs=[
+            # Path to pybind11 headers
+            get_pybind_include(),
+            get_pybind_include(user=True),
+            os.path.join(root, 'cpyquickhelper/fastdata')
+        ],
+        language='c++',
+        define_macros=define_macros)
+
     # cythonize
 
     opts = dict(boundscheck=False, cdivision=True,
@@ -318,7 +335,8 @@ def get_extensions():
             ext_benchmark_dot,
             ext_benchmark_sum_type,
             ext_profiling,
-            ext_profiling_c
+            ext_profiling_c,
+            ext_fast_dict_c
         ])
     return ext_modules
 


### PR DESCRIPTION
The added unit test compares unordered_map with pybind11, python, cython. pybind11 overhead makes it twice slower.

```
2060002 function calls in 3.419 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.088    0.088    3.419    3.419 /_unittests/ut_fastdata/test_fast_dict.py:222(fctN)
     4000    0.018    0.000    1.040    0.000 /_unittests/ut_fastdata/test_fast_dict.py:217(fct4)
     4000    0.020    0.000    1.003    0.000 /_unittests/ut_fastdata/test_fast_dict.py:191(fct2)
     4000    0.527    0.000    0.527    0.000 /_unittests/ut_fastdata/test_fast_dict.py:209(insert4)
     4000    0.511    0.000    0.511    0.000 /_unittests/ut_fastdata/test_fast_dict.py:156(insert2)
     4000    0.495    0.000    0.495    0.000 /_unittests/ut_fastdata/test_fast_dict.py:213(get4)
     4000    0.472    0.000    0.472    0.000 /_unittests/ut_fastdata/test_fast_dict.py:177(get2)
     4000    0.012    0.000    0.465    0.000 /_unittests/ut_fastdata/test_fast_dict.py:181(fct1)
     4000    0.009    0.000    0.453    0.000 /_unittests/ut_fastdata/test_fast_dict.py:204(fct3)
     4000    0.140    0.000    0.371    0.000 /_unittests/ut_fastdata/test_fast_dict.py:163(get1)
     4000    0.008    0.000    0.369    0.000 /_unittests/ut_fastdata/test_fast_dict.py:186(fct11)
     4000    0.128    0.000    0.252    0.000 /_unittests/ut_fastdata/test_fast_dict.py:173(get11)
     4000    0.116    0.000    0.236    0.000 /_unittests/ut_fastdata/test_fast_dict.py:196(insert3)
   400000    0.163    0.000    0.231    0.000 /_unittests/ut_fastdata/test_fast_dict.py:160(g1)
     4000    0.114    0.000    0.207    0.000 /_unittests/ut_fastdata/test_fast_dict.py:200(get3)
   400000    0.124    0.000    0.124    0.000 /_unittests/ut_fastdata/test_fast_dict.py:167(g11)
   400000    0.121    0.000    0.121    0.000 {method 'insert' of 'cpyquickhelper.fastdata.fast_dict_cpy.cmap_int_int' objects}
     4000    0.110    0.000    0.110    0.000 /_unittests/ut_fastdata/test_fast_dict.py:149(insert11)
   400000    0.093    0.000    0.093    0.000 {method 'get' of 'cpyquickhelper.fastdata.fast_dict_cpy.cmap_int_int' objects}
     4000    0.081    0.000    0.081    0.000 /_unittests/ut_fastdata/test_fast_dict.py:145(insert1)
   400000    0.068    0.000    0.068    0.000 {method 'get' of 'dict' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}



.         1236002 function calls in 1.814 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.048    0.048    1.814    1.814 /_unittests/ut_fastdata/test_fast_dict.py:125(fctN)
     4000    0.017    0.000    1.052    0.000 /_unittests/ut_fastdata/test_fast_dict.py:120(fct2)
     4000    0.535    0.000    0.535    0.000 /_unittests/ut_fastdata/test_fast_dict.py:85(insert2)
     4000    0.499    0.000    0.499    0.000 /_unittests/ut_fastdata/test_fast_dict.py:106(get2)
     4000    0.004    0.000    0.391    0.000 /_unittests/ut_fastdata/test_fast_dict.py:110(fct1)
     4000    0.004    0.000    0.324    0.000 /_unittests/ut_fastdata/test_fast_dict.py:115(fct11)
     4000    0.123    0.000    0.318    0.000 /_unittests/ut_fastdata/test_fast_dict.py:92(get1)
     4000    0.115    0.000    0.230    0.000 /_unittests/ut_fastdata/test_fast_dict.py:102(get11)
   400000    0.133    0.000    0.195    0.000 /_unittests/ut_fastdata/test_fast_dict.py:89(g1)
   400000    0.115    0.000    0.115    0.000 /_unittests/ut_fastdata/test_fast_dict.py:96(g11)
     4000    0.089    0.000    0.089    0.000 /_unittests/ut_fastdata/test_fast_dict.py:78(insert11)
     4000    0.069    0.000    0.069    0.000 /_unittests/ut_fastdata/test_fast_dict.py:74(insert1)
   400000    0.062    0.000    0.062    0.000 {method 'get' of 'dict' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```
